### PR TITLE
add support to set custom random number generator contract

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,3 @@
+module.exports = {
+    skipFiles: ['hardhat-dependency-compiler/', "test/"]
+}

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -104,7 +104,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     }
 
     function setRNG(address newRNG) external override restricted {
-        Random.randomSeed(newRNG); // If it fails, address is invalid
+        assert(Random.randomSeed(newRNG) > 0);
         rng = newRNG;
     }
 

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -37,8 +37,8 @@ import { Duration, IStatus } from "@skalenetwork/professional-interfaces/IStatus
 import { TypedSet } from "./structs/typed/TypedSet.sol";
 import { G2Operations } from "./utils/fieldOperations/G2Operations.sol";
 import { PoolLibrary } from "./utils/Pool.sol";
-import { IRandom, Random } from "./utils/Random.sol";
 import { Precompiled } from "./utils/Precompiled.sol";
+import { IRandom, Random } from "./utils/Random.sol";
 
 
 contract Committee is AccessManagedUpgradeable, ICommittee {
@@ -74,7 +74,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     error CommitteeNotFound(
         CommitteeIndex index
     );
-    error InvalidRng(address rng);
+    error InvalidContract(address contractAddress);
 
     modifier onlyDkg() {
         require(msg.sender == address(dkg), SenderIsNotDkg(msg.sender));
@@ -107,9 +107,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
 
     function setRNG(address newRNG) external override restricted {
         skaleRng = newRNG;
-
-        // Will revert if unable to decode bytes32 random
-        _safeRandom();
+        require(_safeRandom() > 0, InvalidContract(newRNG));
     }
 
     function setDkg(IDkg dkgAddress) external override restricted {

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -106,6 +106,8 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     }
 
     function setRNG(address newRNG) external override restricted {
+        // address(0) is allowed here
+        // slither-disable-next-line missing-zero-check
         skaleRng = newRNG;
         require(_safeRandom() > 0, InvalidContract(newRNG));
     }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -38,6 +38,7 @@ import { TypedSet } from "./structs/typed/TypedSet.sol";
 import { G2Operations } from "./utils/fieldOperations/G2Operations.sol";
 import { PoolLibrary } from "./utils/Pool.sol";
 import { IRandom, Random } from "./utils/Random.sol";
+import { Precompiled } from "./utils/Precompiled.sol";
 
 
 contract Committee is AccessManagedUpgradeable, ICommittee {
@@ -53,7 +54,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     INodes public nodes;
     IStatus public status;
     IStaking public staking;
-    address public rng;
+    address public skaleRng;
 
     mapping (CommitteeIndex index => Committee committee) public committees;
     mapping (CommitteeIndex index => CommitteeAuxiliary committee) private _committeesAuxiliary;
@@ -73,6 +74,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     error CommitteeNotFound(
         CommitteeIndex index
     );
+    error InvalidRng(address rng);
 
     modifier onlyDkg() {
         require(msg.sender == address(dkg), SenderIsNotDkg(msg.sender));
@@ -92,20 +94,22 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         committeeSize = 22;
         transitionDelay = Duration.wrap(1 days);
         nodes = nodesAddress;
-        rng = address(0);
+        skaleRng = address(0);
         _initializeCommittee(commonPublicKey);
     }
 
     function select() external override restricted {
-        IRandom.RandomGenerator memory generator = Random.create(Random.randomSeed(rng));
+        IRandom.RandomGenerator memory generator = Random.create(_safeRandom());
         NodeId[] memory members = _pool.sample(committeeSize, generator);
         Committee storage committee = _createSuccessorCommittee(members);
         committee.dkg = dkg.generate(committee.nodes);
     }
 
     function setRNG(address newRNG) external override restricted {
-        assert(Random.randomSeed(newRNG) > 0);
-        rng = newRNG;
+        skaleRng = newRNG;
+
+        // Will revert if unable to decode bytes32 random
+        _safeRandom();
     }
 
     function setDkg(IDkg dkgAddress) external override restricted {
@@ -312,6 +316,13 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
 
     function _committeeExists(CommitteeIndex index) private view returns (bool exists) {
         return !(CommitteeIndex.unwrap(lastCommitteeIndex) < CommitteeIndex.unwrap(index));
+    }
+
+    function _safeRandom() private view returns (uint256 randomNumber) {
+        if (skaleRng == address(0)) {
+            return block.prevrandao;
+        }
+        return Precompiled.getRandomNumber(skaleRng);
     }
 
     function _next(CommitteeIndex index) private pure returns (CommitteeIndex nextIndex) {

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -101,7 +101,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     }
 
     function select() external override restricted {
-        IRandom.RandomGenerator memory generator = Random.create(_getSafeRandom());
+        IRandom.RandomGenerator memory generator = Random.create(_safeGetRandom());
         NodeId[] memory members = _pool.sample(committeeSize, generator);
         Committee storage committee = _createSuccessorCommittee(members);
         committee.dkg = dkg.generate(committee.nodes);
@@ -110,7 +110,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     function setRNG(address newRNG) external override restricted {
         require(newRNG != address(0), InvalidSkaleRngContract(newRNG));
         skaleRng = newRNG;
-        require(_getSafeRandom() > 0, InvalidSkaleRngContract(newRNG));
+        require(_safeGetRandom() > 0, InvalidSkaleRngContract(newRNG));
         emit SkaleRNGEnabled(newRNG);
     }
 
@@ -325,7 +325,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         return !(CommitteeIndex.unwrap(lastCommitteeIndex) < CommitteeIndex.unwrap(index));
     }
 
-    function _getSafeRandom() private view returns (uint256 randomNumber) {
+    function _safeGetRandom() private view returns (uint256 randomNumber) {
         if (skaleRng == address(0)) {
             return block.prevrandao;
         }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -67,6 +67,8 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
 
     event NodeBecomesEligible(NodeId indexed node);
     event NodeLosesEligibility(NodeId indexed node);
+    event SkaleRNGEnabled(address indexed rng);
+    event SkaleRNGDisabled();
 
     error SenderIsNotDkg(
         address sender
@@ -74,7 +76,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     error CommitteeNotFound(
         CommitteeIndex index
     );
-    error InvalidContract(address contractAddress);
+    error InvalidSkaleRngContract(address rng);
 
     modifier onlyDkg() {
         require(msg.sender == address(dkg), SenderIsNotDkg(msg.sender));
@@ -99,17 +101,22 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     }
 
     function select() external override restricted {
-        IRandom.RandomGenerator memory generator = Random.create(_safeRandom());
+        IRandom.RandomGenerator memory generator = Random.create(_getSafeRandom());
         NodeId[] memory members = _pool.sample(committeeSize, generator);
         Committee storage committee = _createSuccessorCommittee(members);
         committee.dkg = dkg.generate(committee.nodes);
     }
 
     function setRNG(address newRNG) external override restricted {
-        // address(0) is allowed here
-        // slither-disable-next-line missing-zero-check
+        require(newRNG != address(0), InvalidSkaleRngContract(newRNG));
         skaleRng = newRNG;
-        require(_safeRandom() > 0, InvalidContract(newRNG));
+        require(_getSafeRandom() > 0, InvalidSkaleRngContract(newRNG));
+        emit SkaleRNGEnabled(newRNG);
+    }
+
+    function disableRNG() external override restricted {
+        skaleRng = address(0);
+        emit SkaleRNGDisabled();
     }
 
     function setDkg(IDkg dkgAddress) external override restricted {
@@ -318,7 +325,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         return !(CommitteeIndex.unwrap(lastCommitteeIndex) < CommitteeIndex.unwrap(index));
     }
 
-    function _safeRandom() private view returns (uint256 randomNumber) {
+    function _getSafeRandom() private view returns (uint256 randomNumber) {
         if (skaleRng == address(0)) {
             return block.prevrandao;
         }

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/*
+    MockRNG.sol - mirage-manager
+    Copyright (C) 2025-Present SKALE Labs
+    @author Dmytro Stebaiev
+
+    mirage-manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    mirage-manager is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with mirage-manager.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+pragma solidity ^0.8.24;
+
+contract MockRNG {
+
+    // Just a Mock
+    // solhint-disable-next-line comprehensive-interface, no-complex-fallback, payable-fallback
+    fallback() external {
+        // compute or hard-code your 32-byte value
+        bytes32 val = keccak256(abi.encodePacked(block.timestamp));
+
+        // Just a Mock: requires assembly to force return
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // store it at memory slot 0x00
+            mstore(0x00, val)
+            // return exactly 32 bytes from memory[0x00..0x20]
+            return(0x00, 0x20)
+        }
+    }
+}

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -30,6 +30,7 @@ contract MockRNG {
         bytes32 val = keccak256(abi.encodePacked(block.timestamp));
 
         // Just a Mock: requires assembly to force return
+        // slither-disable-start assembly
         // solhint-disable-next-line no-inline-assembly
         assembly {
             // store it at memory slot 0x00
@@ -37,5 +38,6 @@ contract MockRNG {
             // return exactly 32 bytes from memory[0x00..0x20]
             return(0x00, 0x20)
         }
+        // slither-disable-end assembly
     }
 }

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -20,12 +20,12 @@
 */
 
 pragma solidity ^0.8.24;
+interface IMockRNG {
+    fallback(bytes calldata) external payable returns (bytes memory result);
+}
+contract MockRNG is IMockRNG{
 
-contract MockRNG {
-
-    // Just a Mock
-    // solhint-disable-next-line comprehensive-interface, payable-fallback
-    fallback(bytes calldata) external returns (bytes memory result) {
+    fallback(bytes calldata) external payable override returns (bytes memory result) {
         return abi.encode(block.timestamp);
     }
 }

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -24,20 +24,8 @@ pragma solidity ^0.8.24;
 contract MockRNG {
 
     // Just a Mock
-    // solhint-disable-next-line comprehensive-interface, no-complex-fallback, payable-fallback
-    fallback() external {
-        // compute or hard-code your 32-byte value
-        bytes32 val = keccak256(abi.encodePacked(block.timestamp));
-
-        // Just a Mock: requires assembly to force return
-        // slither-disable-start assembly
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            // store it at memory slot 0x00
-            mstore(0x00, val)
-            // return exactly 32 bytes from memory[0x00..0x20]
-            return(0x00, 0x20)
-        }
-        // slither-disable-end assembly
+    // solhint-disable-next-line comprehensive-interface, payable-fallback
+    fallback(bytes calldata) external returns (bytes memory result) {
+        return abi.encode(block.timestamp);
     }
 }

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -22,10 +22,15 @@
 pragma solidity ^0.8.24;
 interface IMockRNG {
     fallback(bytes calldata) external payable returns (bytes memory result);
+    function burnEth() external;
 }
 contract MockRNG is IMockRNG{
 
     fallback(bytes calldata) external payable override returns (bytes memory result) {
         return abi.encode(block.timestamp);
+    }
+
+    function burnEth() external override {
+        payable(address(0)).transfer(address(this).balance);
     }
 }

--- a/contracts/test/MockRNG.sol
+++ b/contracts/test/MockRNG.sol
@@ -30,6 +30,7 @@ contract MockRNG is IMockRNG{
         return abi.encode(block.timestamp);
     }
 
+    // required for slither warning
     function burnEth() external override {
         payable(address(0)).transfer(address(this).balance);
     }

--- a/contracts/utils/Precompiled.sol
+++ b/contracts/utils/Precompiled.sol
@@ -94,12 +94,12 @@ library Precompiled {
     }
 
     // rngOnChain should be SKALE Random Number Generator predeployed or similar
-    function getRandomBytes(address rngOnChain) internal view returns (bytes32 addr) {
+    function getRandomBytes32(address rngOnChain) internal view returns (bytes32 addr) {
         return bytes32(_callPrecompiled(rngOnChain, ""));
     }
 
     function getRandomNumber(address rngOnChain) internal view returns (uint256 addr) {
-        return uint256(getRandomBytes(rngOnChain));
+        return uint256(getRandomBytes32(rngOnChain));
     }
 
     // Private

--- a/contracts/utils/Precompiled.sol
+++ b/contracts/utils/Precompiled.sol
@@ -95,11 +95,7 @@ library Precompiled {
 
     // rngOnChain should be SKALE Random Number Generator predeployed or similar
     function getRandomBytes(address rngOnChain) internal view returns (bytes32 addr) {
-        if (rngOnChain == address(0)) {
-            return bytes32(block.prevrandao);
-        }
-
-        return bytes32(_callPrecompiled(rngOnChain, ""));
+        return abi.decode(_callPrecompiled(rngOnChain, ""), (bytes32));
     }
 
     function getRandomNumber(address rngOnChain) internal view returns (uint256 addr) {

--- a/contracts/utils/Precompiled.sol
+++ b/contracts/utils/Precompiled.sol
@@ -95,7 +95,7 @@ library Precompiled {
 
     // rngOnChain should be SKALE Random Number Generator predeployed or similar
     function getRandomBytes(address rngOnChain) internal view returns (bytes32 addr) {
-        return abi.decode(_callPrecompiled(rngOnChain, ""), (bytes32));
+        return bytes32(_callPrecompiled(rngOnChain, ""));
     }
 
     function getRandomNumber(address rngOnChain) internal view returns (uint256 addr) {

--- a/contracts/utils/Random.sol
+++ b/contracts/utils/Random.sol
@@ -22,12 +22,19 @@
 pragma solidity ^0.8.24;
 
 import { IRandom } from "@skalenetwork/professional-interfaces/IRandom.sol";
+import { Precompiled } from "./fieldOperations/Precompiled.sol";
 
 /**
  * @title Random
  * @dev The library for generating of pseudo random numbers
  */
 library Random {
+    /**
+     * @dev Retrieves randomSeed from rng
+     */
+    function randomSeed(address rng) internal view returns (uint256 seed) {
+        return Precompiled.getRandomNumber(rng);
+    }
 
     /**
      * @dev Create an instance of RandomGenerator

--- a/contracts/utils/Random.sol
+++ b/contracts/utils/Random.sol
@@ -22,19 +22,12 @@
 pragma solidity ^0.8.24;
 
 import { IRandom } from "@skalenetwork/professional-interfaces/IRandom.sol";
-import { Precompiled } from "./fieldOperations/Precompiled.sol";
 
 /**
  * @title Random
  * @dev The library for generating of pseudo random numbers
  */
 library Random {
-    /**
-     * @dev Retrieves randomSeed from rng
-     */
-    function randomSeed(address rng) internal view returns (uint256 seed) {
-        return Precompiled.getRandomNumber(rng);
-    }
 
     /**
      * @dev Create an instance of RandomGenerator

--- a/contracts/utils/fieldOperations/Fp2Operations.sol
+++ b/contracts/utils/fieldOperations/Fp2Operations.sol
@@ -26,7 +26,7 @@ pragma solidity ^0.8.24;
 
 import { IDkg } from "@skalenetwork/professional-interfaces/IDkg.sol";
 
-import { Precompiled } from "./Precompiled.sol";
+import { Precompiled } from "../Precompiled.sol";
 
 
 library Fp2Operations {

--- a/contracts/utils/fieldOperations/Precompiled.sol
+++ b/contracts/utils/fieldOperations/Precompiled.sol
@@ -93,6 +93,19 @@ library Precompiled {
         return abi.decode(output, (uint256)) != 0;
     }
 
+    // rngOnChain should be SKALE Random Number Generator predeployed or simmilar
+    function getRandomBytes(address rngOnChain) internal view returns (bytes32 addr) {
+        if (rngOnChain == address(0)) {
+            return bytes32(block.prevrandao);
+        }
+
+        return bytes32(_callPrecompiled(rngOnChain, ""));
+    }
+
+    function getRandomNumber(address rngOnChain) internal view returns (uint256 addr) {
+        return uint256(getRandomBytes(rngOnChain));
+    }
+
     // Private
 
     function _callPrecompiled(

--- a/contracts/utils/fieldOperations/Precompiled.sol
+++ b/contracts/utils/fieldOperations/Precompiled.sol
@@ -93,7 +93,7 @@ library Precompiled {
         return abi.decode(output, (uint256)) != 0;
     }
 
-    // rngOnChain should be SKALE Random Number Generator predeployed or simmilar
+    // rngOnChain should be SKALE Random Number Generator predeployed or similar
     function getRandomBytes(address rngOnChain) internal view returns (bytes32 addr) {
         if (rngOnChain == address(0)) {
             return bytes32(block.prevrandao);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,8 @@ export default [
       ".pnp.cjs",
       "coverage/",
       "typechain-types/",
-      "venv/"
+      "venv/",
+      ".solcover.js"
     ],
   }
 ];

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,15 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.28",
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      }
+    }
+  },
   networks: {
     custom: {
       url: process.env.ENDPOINT || "http://localhost:8545",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,7 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.28",
+    version: "0.8.30",
     settings: {
       optimizer: {
         enabled: true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "0.1.0-random-generator.0",
+    "@skalenetwork/professional-interfaces": "0.1.0-random-generator.1",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "0.1.0-random-generator.1",
+    "@skalenetwork/professional-interfaces": "0.1.0-develop.76",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.2",
+    "@skalenetwork/professional-interfaces": "0.1.0-random-generator.0",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -164,7 +164,7 @@ describe("Committee", () => {
         await committee.setRNG(rng);
 
         // This should revert if address is invalid
-        await committee.setRNG(hacker).should.be.reverted;
+        await committee.setRNG(hacker).should.be.revertedWithCustomError(committee, "InvalidContract");
 
         expect(await committee.skaleRng()).to.equal(await rng.getAddress());
     });

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -166,7 +166,7 @@ describe("Committee", () => {
         // This should revert if address is invalid
         await committee.setRNG(hacker).should.be.reverted;
 
-        expect(await committee.rng()).to.equal(await rng.getAddress());
+        expect(await committee.skaleRng()).to.equal(await rng.getAddress());
     });
 
     it("should set committee size", async () => {

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -155,7 +155,7 @@ describe("Committee", () => {
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should set rng contract", async () => {
+    it("should enable and disable rng contract", async () => {
         const {committee} = await whitelistedAndStakedAndHealthyNodes();
         const rng = await ethers.deployContract("MockRNG");
         await rng.waitForDeployment();
@@ -164,14 +164,15 @@ describe("Committee", () => {
         await committee.setRNG(rng);
 
         // This should revert if address is invalid
-        await committee.setRNG(hacker).should.be.revertedWithCustomError(committee, "InvalidContract");
+        await committee.setRNG(hacker).should.be.revertedWithCustomError(committee, "InvalidSkaleRngContract");
 
         expect(await committee.skaleRng()).to.equal(await rng.getAddress());
+        await committee.disableRNG();
+        expect(await committee.skaleRng()).to.equal(ethers.ZeroAddress);
     });
 
    it("should select committee with custom rng", async function () {
-        this.timeout(600000); // 10 minutes timeout. DKG requires a lot of time
-        const {committee, dkg, nodesData} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee} = await whitelistedAndStakedAndHealthyNodes();
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();
         const nextCommitteeIndex = activeCommitteeIndex + 1n;
         const rng = await ethers.deployContract("MockRNG");
@@ -179,26 +180,12 @@ describe("Committee", () => {
         await committee.setRNG(rng);
         expect(await committee.skaleRng()).to.equal(await rng.getAddress());
 
-
         await committee.select();
 
-        let nextCommittee = await committee.getCommittee(nextCommitteeIndex);
+        const nextCommittee = await committee.getCommittee(nextCommitteeIndex);
         nextCommittee.dkg.should.not.be.equal(0n);
         nextCommittee.startingTimestamp.should.be.equal(2n ** 256n - 1n);
         nextCommittee.nodes.length.should.be.equal(await committee.committeeSize());
-
-        await runDkg(dkg, nodesData, nextCommittee.dkg);
-
-        nextCommittee = await committee.getCommittee(nextCommitteeIndex);
-        const lastTransactionTimestamp = (await ethers.provider.getBlock("latest"))?.timestamp;
-        assert(lastTransactionTimestamp);
-        nextCommittee.startingTimestamp.should.be.equal(
-            BigInt(lastTransactionTimestamp) + (await committee.transitionDelay())
-        );
-        nextCommittee.commonPublicKey.x.a.should.not.be.equal(0n);
-        nextCommittee.commonPublicKey.x.b.should.not.be.equal(0n);
-        nextCommittee.commonPublicKey.y.a.should.not.be.equal(0n);
-        nextCommittee.commonPublicKey.y.b.should.not.be.equal(0n);
     });
 
     it("should set committee size", async () => {

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -159,9 +159,12 @@ describe("Committee", () => {
         const {committee} = await whitelistedAndStakedAndHealthyNodes();
         const rng = await ethers.deployContract("MockRNG");
         await rng.waitForDeployment();
+        const [, hacker] = await ethers.getSigners();
 
-        // This automaticaly tests if call to random is succeeded
         await committee.setRNG(rng);
+
+        // This should revert if address is invalid
+        await committee.setRNG(hacker).should.be.reverted;
 
         expect(await committee.rng()).to.equal(await rng.getAddress());
     });

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -114,7 +114,14 @@ describe("Committee", () => {
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow everyone to set nodes contract", async () => {
+    it("should not allow anyone to set rng contract", async () => {
+        const [, hacker] = await ethers.getSigners();
+        const {committee} = await cleanDeployment();
+        await committee.connect(hacker).setRNG(hacker)
+            .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
+    });
+
+    it("should not allow anyone to set nodes contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setNodes(hacker)
@@ -146,6 +153,17 @@ describe("Committee", () => {
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setTransitionDelay(0xd2n)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
+    });
+
+    it("should set rng contract", async () => {
+        const {committee} = await whitelistedAndStakedAndHealthyNodes();
+        const rng = await ethers.deployContract("MockRNG");
+        await rng.waitForDeployment();
+
+        // This automaticaly tests if call to random is succeeded
+        await committee.setRNG(rng);
+
+        expect(await committee.rng()).to.equal(await rng.getAddress());
     });
 
     it("should set committee size", async () => {

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -114,14 +114,14 @@ describe("Committee", () => {
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to set rng contract", async () => {
+    it("should not allow everyone to set rng contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setRNG(hacker)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to set nodes contract", async () => {
+    it("should not allow everyone to set nodes contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setNodes(hacker)

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -174,9 +174,7 @@ describe("Committee", () => {
    it("should select committee with custom rng", async function () {
         const {committee, nodesData, status} = await whitelistedAndStakedNodes();
         await committee.setCommitteeSize(5);
-        for (const node of nodesData.slice(0, 5)) {
-            await status.connect(node.wallet).alive();
-        }
+        await sendHeartbeat(status, nodesData.slice(0, 5));
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();
         const nextCommitteeIndex = activeCommitteeIndex + 1n;
         const rng = await ethers.deployContract("MockRNG");

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -156,7 +156,7 @@ describe("Committee", () => {
     });
 
     it("should enable and disable rng contract", async () => {
-        const {committee} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee} = await cleanDeployment();
         const rng = await ethers.deployContract("MockRNG");
         await rng.waitForDeployment();
         const [, hacker] = await ethers.getSigners();

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -172,14 +172,17 @@ describe("Committee", () => {
     });
 
    it("should select committee with custom rng", async function () {
-        const {committee} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee, nodesData, status} = await whitelistedAndStakedNodes();
+        await committee.setCommitteeSize(5);
+        for (const node of nodesData.slice(0, 5)) {
+            await status.connect(node.wallet).alive();
+        }
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();
         const nextCommitteeIndex = activeCommitteeIndex + 1n;
         const rng = await ethers.deployContract("MockRNG");
         await rng.waitForDeployment();
         await committee.setRNG(rng);
         expect(await committee.skaleRng()).to.equal(await rng.getAddress());
-
         await committee.select();
 
         const nextCommittee = await committee.getCommittee(nextCommitteeIndex);

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -169,6 +169,15 @@ describe("Committee", () => {
         expect(await committee.skaleRng()).to.equal(await rng.getAddress());
     });
 
+    it("should select committee with custom rng contract", async () => {
+        const {committee} = await whitelistedAndStakedAndHealthyNodes();
+        const rng = await ethers.deployContract("MockRNG");
+        await rng.waitForDeployment();
+        await committee.setRNG(rng);
+        expect(await committee.skaleRng()).to.equal(await rng.getAddress());
+
+    });
+
     it("should set committee size", async () => {
         const {committee, nodesData, status} = await whitelistedAndStakedNodes();
         const newSize = 13;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.0":
-  version: 0.1.0-random-generator.0
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.0"
-  checksum: 10c0/c11dec9bb2667e999a71e174deff1cb885549e8173a60ac640aa4fb8770110a713fca8e7fed1d58419239ff352f1e7dff41c7797f02401849b6fe81eb2e834ea
+"@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.1":
+  version: 0.1.0-random-generator.1
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.1"
+  checksum: 10c0/f33e33f708a1eb97f608c402afd60e1ca681628844f694a25a5980984f5b45306a1806a69033e60c329595911a8dc90c5222ac376ae8ba37a9c7820eb6a9c799
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:0.1.0-random-generator.0"
+    "@skalenetwork/professional-interfaces": "npm:0.1.0-random-generator.1"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.1":
-  version: 0.1.0-random-generator.1
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.1"
-  checksum: 10c0/f33e33f708a1eb97f608c402afd60e1ca681628844f694a25a5980984f5b45306a1806a69033e60c329595911a8dc90c5222ac376ae8ba37a9c7820eb6a9c799
+"@skalenetwork/professional-interfaces@npm:0.1.0-develop.76":
+  version: 0.1.0-develop.76
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-develop.76"
+  checksum: 10c0/9916b024484b84491bd8e784aa404690e223e017c4e351c0754a41e587f3299bebd83ab30251c084db8d414a2d6b6e5ec8841f4cc449025099438d74445b95cc
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:0.1.0-random-generator.1"
+    "@skalenetwork/professional-interfaces": "npm:0.1.0-develop.76"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.2":
-  version: 0.1.0-unhealthy.2
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.2"
-  checksum: 10c0/0cb948564c22eef1945d90ddfc13e562137b689ee4acc9c4d730b5336c9193ee39711ebccb28b7ab06489f800025bea679f7d92fd4e5d75ff096542b3f7fa449
+"@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.0":
+  version: 0.1.0-random-generator.0
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-random-generator.0"
+  checksum: 10c0/c11dec9bb2667e999a71e174deff1cb885549e8173a60ac640aa4fb8770110a713fca8e7fed1d58419239ff352f1e7dff41c7797f02401849b6fe81eb2e834ea
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.2"
+    "@skalenetwork/professional-interfaces": "npm:0.1.0-random-generator.0"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"


### PR DESCRIPTION
We want to be able to use SKALE Random Number Generator for true and verifiable randomness. We add the option to set a contract address to this contract on Committee, or if set to 0 it will return block.prevrandao.

Added test in Committee.ts

Fixes #30 