### PR TITLE
Don't reward delegators of unhealthy nodes

### DIFF
--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -170,6 +170,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         } else {
             if (status.isWhitelisted(node) && staking.getNodeShare(node) > 0) {
                 _setEligible(node);
+                _pool.moveToFront(
+                    node,
+                    _shareToWeight(staking.getNodeShare(node))
+                );
             }
         }
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -136,7 +136,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
                 FundLibrary.addressToHolder(msg.sender),
                 value
             );
-            _disabledNodesBalances.set(node, nodeFundBalance - value);
+            assert(!_disabledNodesBalances.set(node, nodeFundBalance - value));
         }
 
         if (_nodesFunds[node].credits[FundLibrary.addressToHolder(msg.sender)] == FundLibrary.ZERO_CREDIT) {
@@ -190,7 +190,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
                 FundLibrary.addressToHolder(msg.sender),
                 amount
             );
-            _disabledNodesBalances.set(node, nodeFundBalance + amount);
+            assert(!_disabledNodesBalances.set(node, nodeFundBalance + amount));
         }
         if(_stakedNodes[msg.sender].add(node)) {
             emit StakedToNewNode(msg.sender, node);

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -82,7 +82,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         claimFee(to, getEarnedFeeAmount(nodes.getNodeId(msg.sender)));
     }
 
-    function disable(NodeId node) external restricted {
+    function disable(NodeId node) external override restricted {
         Mirage balance = _getTotalBalance();
         Mirage nodeFundBalance = _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node));
         _rootFund.remove(
@@ -96,7 +96,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         committee.updateWeight(node, 0);
     }
 
-    function enable(NodeId node) external restricted {
+    function enable(NodeId node) external override restricted {
         (bool wasDisabled, Mirage value) = _disabledNodesBalances.tryGet(node);
         require(wasDisabled, NodeIsNotDisabled(node));
         Mirage balance = _getTotalBalance();
@@ -278,7 +278,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         if (_disabledNodesBalances.contains(node)) {
             nodeBalance = _disabledNodesBalances.get(node);
         } else {
-          nodeBalance = _rootFund.getBalance(_getTotalBalance(), FundLibrary.nodeToHolder(node));
+            nodeBalance = _rootFund.getBalance(_getTotalBalance(), FundLibrary.nodeToHolder(node));
         }
         return _nodesFunds[node].getBalance(
             nodeBalance,

--- a/contracts/structs/SplayTree.sol
+++ b/contracts/structs/SplayTree.sol
@@ -130,6 +130,17 @@ library SplayTree {
         revert NotFound();
     }
 
+    function findLast(mapping(NodeId => Node) storage nodes, NodeId root) internal returns (NodeId newRoot) {
+        NodeId node = root;
+        while (node != SplayTree.NULL) {
+            if (nodes[node].right == SplayTree.NULL) {
+                return splay(nodes, node);
+            }
+            node = nodes[node].right;
+        }
+        revert NotFound();
+    }
+
     function splay(mapping(NodeId => Node) storage nodes, NodeId id) internal returns (NodeId newRoot) {
         require(id != NULL, SplayOnNull());
         if (nodes[id].parent != NULL) {

--- a/contracts/structs/typed/TypedMap.sol
+++ b/contracts/structs/typed/TypedMap.sol
@@ -22,6 +22,7 @@ pragma solidity ^0.8.24;
 
 import { EnumerableMap } from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import { NodeId } from "@skalenetwork/professional-interfaces/INodes.sol";
+import { Mirage } from "@skalenetwork/professional-interfaces/units.sol";
 
 import { TypedSet } from "./TypedSet.sol";
 
@@ -34,6 +35,10 @@ library TypedMap {
 
     struct AddressToNodeIdSetMap {
         mapping(address => TypedSet.NodeIdSet) inner;
+    }
+
+    struct NodeIdToMirageMap {
+        EnumerableMap.UintToUintMap inner;
     }
 
     // ----------
@@ -57,6 +62,16 @@ library TypedMap {
 
     function remove(AddressToNodeIdSetMap storage map, address key, NodeId nodeId) internal returns (bool removed) {
         removed = map.inner[key].remove(nodeId);
+    }
+
+    // NodeIdToMirageMap
+
+    function set(NodeIdToMirageMap storage map, NodeId key, Mirage value) internal returns (bool added) {
+        added = EnumerableMap.set(map.inner, NodeId.unwrap(key), Mirage.unwrap(value));
+    }
+
+    function remove(NodeIdToMirageMap storage map, NodeId key) internal returns (bool removed) {
+        removed = EnumerableMap.remove(map.inner, NodeId.unwrap(key));
     }
 
     // --------------
@@ -93,5 +108,21 @@ library TypedMap {
 
     function isSet(AddressToNodeIdSetMap storage map, address key, NodeId nodeId) internal view returns (bool result) {
         result = map.inner[key].contains(nodeId);
+    }
+
+    // NodeIdToMirageMap
+
+    function get(NodeIdToMirageMap storage map, NodeId key) internal view returns (Mirage value) {
+        return Mirage.wrap(EnumerableMap.get(map.inner, NodeId.unwrap(key)));
+    }
+
+    function contains(NodeIdToMirageMap storage map, NodeId key) internal view returns (bool result) {
+        result = EnumerableMap.contains(map.inner, NodeId.unwrap(key));
+    }
+
+    function tryGet(NodeIdToMirageMap storage map, NodeId key) internal view returns (bool success, Mirage value) {
+        uint256 rawValue;
+        (success, rawValue) = EnumerableMap.tryGet(map.inner, NodeId.unwrap(key));
+        value = Mirage.wrap(rawValue);
     }
 }

--- a/contracts/utils/Pool.sol
+++ b/contracts/utils/Pool.sol
@@ -104,6 +104,17 @@ library PoolLibrary {
         }
     }
 
+    function getOldestIsh(Pool storage pool) internal returns (NodeId oldest) {
+        if (pool.incomingNodes.length() > 0) {
+            return pool.incomingNodes.at(0);
+        }
+        if (pool.root == SplayTree.NULL) {
+            return SplayTree.NULL;
+        }
+        pool.root = pool.tree.findLast(pool.root);
+        return pool.root;
+    }
+
     function contains(Pool storage pool, NodeId node) internal view returns (bool present) {
         return pool.presentNodes.contains(node) || pool.incomingNodes.contains(node);
     }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "0.1.0-develop.74",
+    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.0",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.1",
+    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.2",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.0",
+    "@skalenetwork/professional-interfaces": "^0.1.0-unhealthy.1",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -73,9 +73,9 @@ describe("Committee", () => {
         expect(newVersion).to.be.eql(await committee.version());
     });
 
-    it("should not allow anyone to start committee rotation", async () => {
+    it("should not allow everyone to start committee rotation", async () => {
         const [, hacker] = await ethers.getSigners();
-        const {committee} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee} = await whitelistedAndStakedNodes();
         await committee.connect(hacker).select()
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
@@ -107,41 +107,41 @@ describe("Committee", () => {
         nextCommittee.commonPublicKey.y.b.should.not.be.equal(0n);
     });
 
-    it("should not allow anyone to set dkg contract", async () => {
+    it("should not allow everyone to set dkg contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setDkg(hacker)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to set nodes contract", async () => {
+    it("should not allow everyone to set nodes contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setNodes(hacker)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to set status contract", async () => {
+    it("should not allow everyone to set status contract", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setStatus(hacker)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to call successful dkg", async () => {
+    it("should not allow everyone to call successful dkg", async () => {
         const {committee} = await cleanDeployment();
         await committee.processSuccessfulDkg(0xd2n)
             .should.be.revertedWithCustomError(committee, "SenderIsNotDkg");
     });
 
-    it("should not allow anyone to set committee", async () => {
+    it("should not allow everyone to set committee", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setCommitteeSize(0xd2n)
             .should.be.revertedWithCustomError(committee, "AccessManagedUnauthorized");
     });
 
-    it("should not allow anyone to set transition delay", async () => {
+    it("should not allow everyone to set transition delay", async () => {
         const [, hacker] = await ethers.getSigners();
         const {committee} = await cleanDeployment();
         await committee.connect(hacker).setTransitionDelay(0xd2n)

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -149,11 +149,12 @@ describe("Committee", () => {
     });
 
     it("should set committee size", async () => {
-        const {committee} = await whitelistedAndStakedAndHealthyNodes();
-        const newSize = 13n;
+        const {committee, nodesData, status} = await whitelistedAndStakedNodes();
+        const newSize = 13;
 
         await committee.setCommitteeSize(newSize);
 
+        await sendHeartbeat(status, nodesData.slice(0, newSize));
         (await committee.committeeSize()).should.be.equal(newSize);
 
         await committee.select();

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -187,12 +187,10 @@ describe("Committee", () => {
         );
     });
 
-    it("should check if a node in the committee or will be there soon", async function () {
-        // TODO: this test does not fit standard timelimit with old nodejs
-        // remove this line after stop using nodejs 20
-        this.timeout(50000); // slightly increase timeout for older nodejs
-        const {committee, dkg, nodesData, status} = await whitelistedAndStakedAndHealthyNodes();
-        await committee.setCommitteeSize(5);
+    it("should check if a node in the committee or will be there soon", async () => {
+        const {committee, dkg, nodesData, status} = await whitelistedAndStakedNodes();
+        await committee.setCommitteeSize(5); // to save time
+        await sendHeartbeat(status, nodesData.slice(0, 15)); // to save time
 
         await committee.select();
         await runDkg(

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -190,7 +190,7 @@ describe("Committee", () => {
     it("should check if a node in the committee or will be there soon", async () => {
         const {committee, dkg, nodesData, status} = await whitelistedAndStakedNodes();
         await committee.setCommitteeSize(5); // to save time
-        await sendHeartbeat(status, nodesData.slice(0, 15)); // to save time
+        await sendHeartbeat(status, nodesData.slice(0, 10)); // to save time
 
         await committee.select();
         await runDkg(
@@ -263,8 +263,9 @@ describe("Committee", () => {
     });
 
     it("should restart committee selection", async () => {
-        const {committee, dkg, nodesData} = await whitelistedAndStakedAndHealthyNodes();
-        await committee.setCommitteeSize(5);
+        const {committee, dkg, nodesData, status} = await whitelistedAndStakedNodes();
+        await committee.setCommitteeSize(5); // to save time
+        await sendHeartbeat(status, nodesData.slice(0, 10)); // to save time
 
         await committee.select();
         const badNextCommittee = await committee.getCommittee(await committee.getActiveCommitteeIndex() + 1n);

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -199,9 +199,7 @@ describe("Committee", () => {
             (await committee.getCommittee(await committee.getActiveCommitteeIndex() + 1n)).dkg
         );
         await skipTime(await committee.transitionDelay());
-        for (const node of nodesData) {
-            await status.connect(node.wallet).alive();
-        }
+        await sendHeartbeat(status, nodesData.slice(0, 10)); // not all nodes to save time
         await committee.select();
 
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
-import { cleanDeployment, whitelistedAndStakedAndHealthyNodes } from "./tools/fixtures";
+import { cleanDeployment, sendHeartbeat, whitelistedAndStakedNodes } from "./tools/fixtures";
 import { Nodes } from "../typechain-types";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -377,12 +377,10 @@ describe("Nodes", function () {
         .to.be.revertedWithCustomError(nodesContract, "PassiveNodeAlreadyExistsForAddress");
     });
 
-    it("should should not allow changing nodes data if node in current or next committee", async function () {
-        // TODO: this test does not fit standard timelimit with old nodejs
-        // remove this line after stop using nodejs 20
-        this.timeout(50000); // slightly increase timeout for older nodejs
-        const {committee, nodesData, nodes} = await whitelistedAndStakedAndHealthyNodes();
+    it("should should not allow changing nodes data if node in current or next committee", async () => {
+        const {committee, nodesData, nodes, status} = await whitelistedAndStakedNodes();
         await committee.setCommitteeSize(5); // to save resources
+        await sendHeartbeat(status, nodesData.slice(0, 10)); // to save time
         await committee.select();
 
         for(const node of nodesData) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:0.1.0-develop.74":
-  version: 0.1.0-develop.74
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-develop.74"
-  checksum: 10c0/b8de6716737eb21d28f57f84248b0b368da531990b37c798dfdad2961f4e9db13e81849e2600a8fb848021516c1372564d346a8880d73e79a6d2c81c63a43480
+"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.0":
+  version: 0.1.0-unhealthy.0
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.0"
+  checksum: 10c0/50f777823ca34e4eec2cb84d99d0507a7b36eb7547ac074affd1c95ec01523e40187965864d00820b52d80c7ae8886e44fd7594177804e9689511e5c524943a7
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:0.1.0-develop.74"
+    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.0"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.0":
-  version: 0.1.0-unhealthy.0
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.0"
-  checksum: 10c0/50f777823ca34e4eec2cb84d99d0507a7b36eb7547ac074affd1c95ec01523e40187965864d00820b52d80c7ae8886e44fd7594177804e9689511e5c524943a7
+"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.1":
+  version: 0.1.0-unhealthy.1
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.1"
+  checksum: 10c0/baceb5300b1f30de86b679e1af5e51c862f271fa3680ef6b1b2c60138070afbd5908465fc9da8fb74dd4c035aa6818a0b0719f126e4414b6958a84d34fdab176
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.0"
+    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.1"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.1":
-  version: 0.1.0-unhealthy.1
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.1"
-  checksum: 10c0/baceb5300b1f30de86b679e1af5e51c862f271fa3680ef6b1b2c60138070afbd5908465fc9da8fb74dd4c035aa6818a0b0719f126e4414b6958a84d34fdab176
+"@skalenetwork/professional-interfaces@npm:^0.1.0-unhealthy.2":
+  version: 0.1.0-unhealthy.2
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-unhealthy.2"
+  checksum: 10c0/0cb948564c22eef1945d90ddfc13e562137b689ee4acc9c4d730b5336c9193ee39711ebccb28b7ab06489f800025bea679f7d92fd4e5d75ff096542b3f7fa449
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.1"
+    "@skalenetwork/professional-interfaces": "npm:^0.1.0-unhealthy.2"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"


### PR DESCRIPTION
- add ability to `Staking` to not distribute rewards to specified validators
- refactor `Committee` to store only eligible nodes
- add "it should not pay rewards to stakers of unhealthy nodes" test
- speed up tests