### PR TITLE
Change order of registering nodes during initialization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,6 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -262,7 +262,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     function _initializeCommittee(
         IDkg.G2Point memory commonPublicKey
     ) private {
-        NodeId[] memory nodeIds = nodes.getActiveNodesIds();
+        NodeId[] memory nodeIds = nodes.getActiveNodeIds();
         committeeSize = nodeIds.length;
         Committee storage initialCommittee =
             _createCommittee(nodeIds, CommitteeIndex.wrap(0));

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -414,7 +414,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         uint256 length = initialNodes.length;
         for (uint256 i; i < length; ++i) {
             Node calldata initNode = initialNodes[i];
-
+            require(
+                NodeId.unwrap(initNode.id) == _nodeIdCounter,
+                "Invalid node ID"
+            );
             _createActiveNode({
                 nodeAddress: initNode.nodeAddress,
                 ip: initNode.ip,

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -91,6 +91,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     error PortShouldNotBeZero();
     error SenderIsNotNodeOwner();
     error SenderIsNotNewNodeOwner();
+    error InvalidNodeId(NodeId nodeId, NodeId expected);
 
     modifier nodeNotInCurrentOrNextCommittee(NodeId nodeId){
         require(
@@ -416,7 +417,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             Node calldata initNode = initialNodes[i];
             require(
                 NodeId.unwrap(initNode.id) == _nodeIdCounter,
-                "Invalid node ID"
+                InvalidNodeId(initNode.id, NodeId.wrap(_nodeIdCounter))
             );
             _createActiveNode({
                 nodeAddress: initNode.nodeAddress,

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -315,7 +315,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         nodeId = _activeNodesAddressToId.get(nodeAddress);
     }
 
-    function getPassiveNodesIdsForAddress(
+    function getPassiveNodeIdsForAddress(
         address nodeAddress
     )
         external
@@ -330,11 +330,11 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         nodeIds = _passiveNodeIdByAddress.getValuesAt(nodeAddress);
     }
 
-    function getPassiveNodesIds() external view override returns (NodeId[] memory nodeIds) {
+    function getPassiveNodeIds() external view override returns (NodeId[] memory nodeIds) {
         nodeIds = _passiveNodeIds.values();
     }
 
-    function getActiveNodesIds() external view override returns (NodeId[] memory nodeIds) {
+    function getActiveNodeIds() external view override returns (NodeId[] memory nodeIds) {
         nodeIds = _activeNodeIds.values();
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -161,10 +161,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             msg.sender == nodeAddress,
             InvalidPublicKeyForSender(publicKey, nodeAddress, msg.sender)
         );
-        unchecked {
-            ++_nodeIdCounter;
-        }
-        NodeId nextNodeId = NodeId.wrap(_nodeIdCounter);
+        NodeId nextNodeId = NodeId.wrap(_nodeIdCounter + 1);
         _createActiveNode({
             nodeId: nextNodeId,
             nodeAddress: msg.sender,
@@ -358,10 +355,11 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         internal
     {
         require(NodeId.unwrap(nodeId) > _nodeIdCounter, InvalidNodeId(nodeId, _nodeIdCounter));
+        require(_usedIps.add(keccak256(ip)), IpIsNotAvailable(ip));
+
+        _nodeIdCounter = NodeId.unwrap(nodeId);
         _addActiveNodeId(nodeId);
         _setActiveNodeIdForAddress(nodeAddress, nodeId);
-
-        require(_usedIps.add(keccak256(ip)), IpIsNotAvailable(ip));
 
         nodes[nodeId] = Node({
             id: nodeId,
@@ -422,7 +420,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
                 domainName: initNode.domainName,
                 publicKey: initNode.publicKey
             });
-            _nodeIdCounter = NodeId.unwrap(initNode.id);
         }
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -91,7 +91,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     error PortShouldNotBeZero();
     error SenderIsNotNodeOwner();
     error SenderIsNotNewNodeOwner();
-    error InvalidNodeId(NodeId nodeId, uint256 numberOfNodes);
+    error InvalidNodeId(NodeId nodeId, uint256 nodeIdCounter);
 
     modifier nodeNotInCurrentOrNextCommittee(NodeId nodeId){
         require(
@@ -161,7 +161,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             msg.sender == nodeAddress,
             InvalidPublicKeyForSender(publicKey, nodeAddress, msg.sender)
         );
-        NodeId nextNodeId = NodeId.wrap(_nodeIdCounter + 1);
+        unchecked {
+            ++_nodeIdCounter;
+        }
+        NodeId nextNodeId = NodeId.wrap(_nodeIdCounter);
         _createActiveNode({
             nodeId: nextNodeId,
             nodeAddress: msg.sender,
@@ -355,9 +358,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         internal
     {
         require(NodeId.unwrap(nodeId) > _nodeIdCounter, InvalidNodeId(nodeId, _nodeIdCounter));
-        unchecked {
-            ++_nodeIdCounter;
-        }
         _addActiveNodeId(nodeId);
         _setActiveNodeIdForAddress(nodeAddress, nodeId);
 
@@ -422,6 +422,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
                 domainName: initNode.domainName,
                 publicKey: initNode.publicKey
             });
+            _nodeIdCounter = NodeId.unwrap(initNode.id);
         }
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -415,17 +415,18 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         uint256 length = initialNodes.length;
         for (uint256 i; i < length; ++i) {
             Node calldata initNode = initialNodes[i];
-            require(
-                NodeId.unwrap(initNode.id) == _nodeIdCounter,
-                InvalidNodeId(initNode.id, NodeId.wrap(_nodeIdCounter))
-            );
-            _createActiveNode({
+
+            NodeId createdNodeId =_createActiveNode({
                 nodeAddress: initNode.nodeAddress,
                 ip: initNode.ip,
                 port: initNode.port,
                 domainName: initNode.domainName,
                 publicKey: initNode.publicKey
             });
+            require(
+                NodeId.unwrap(initNode.id) + 1 == NodeId.unwrap(createdNodeId),
+                InvalidNodeId(initNode.id, createdNodeId)
+            );
         }
     }
 

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -69,7 +69,12 @@ async function fetchNodes() {
     const nodes = await skaleManagerInstance.getContract("Nodes") as unknown as INodesInSkaleManager;
     const schainsInternal = await skaleManagerInstance.getContract("SchainsInternal") as unknown as ISchainsInternal;
     const nodeIds = await schainsInternal.getNodesInGroup(mirageChainHash);
-    const nodeIdsSorted = nodeIds.map(nodeId => Number(nodeId)).sort((a, b) => a - b);
+    const nodeIdsSorted = nodeIds.map(Number).sort((a, b) => a - b);
+    for (let i = 0; i < nodeIdsSorted.length; i++) {
+        if (nodeIdsSorted[i] !== i) {
+            throw new Error(`Node IDs are not consecutive from 0 to n. Expected ${i}, but found ${nodeIds[i]}`);
+        }
+    }
     const nodeList: INodes.NodeStruct[] = [];
     for (const id of nodeIdsSorted) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -68,9 +68,9 @@ async function fetchNodes() {
     const skaleManagerInstance = await getSkaleManagerInstance();
     const nodes = await skaleManagerInstance.getContract("Nodes") as unknown as INodesInSkaleManager;
     const schainsInternal = await skaleManagerInstance.getContract("SchainsInternal") as unknown as ISchainsInternal;
-    const nodesInGroup = await schainsInternal.getNodesInGroup(mirageChainHash);
+    const numberOfNodesInGroup = await schainsInternal.getNumberOfNodesInGroup(mirageChainHash);
     const nodeList: INodes.NodeStruct[] = [];
-    for (const nodeId of nodesInGroup) {
+    for (let nodeId = 0; nodeId < numberOfNodesInGroup; ++nodeId) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
             nodes.getNodeIP(nodeId),
             nodes.getNodeDomainName(nodeId),

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -68,18 +68,19 @@ async function fetchNodes() {
     const skaleManagerInstance = await getSkaleManagerInstance();
     const nodes = await skaleManagerInstance.getContract("Nodes") as unknown as INodesInSkaleManager;
     const schainsInternal = await skaleManagerInstance.getContract("SchainsInternal") as unknown as ISchainsInternal;
-    const numberOfNodesInGroup = await schainsInternal.getNumberOfNodesInGroup(mirageChainHash);
+    const nodeIds = await schainsInternal.getNodesInGroup(mirageChainHash);
+    const nodeIdsSorted = nodeIds.map(nodeId => Number(nodeId)).sort((a, b) => a - b);
     const nodeList: INodes.NodeStruct[] = [];
-    for (let nodeId = 0; nodeId < numberOfNodesInGroup; ++nodeId) {
+    for (const id of nodeIdsSorted) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
-            nodes.getNodeIP(nodeId),
-            nodes.getNodeDomainName(nodeId),
-            nodes.getNodeAddress(nodeId),
-            nodes.getNodePort(nodeId),
-            nodes.getNodePublicKey(nodeId)
+            nodes.getNodeIP(id),
+            nodes.getNodeDomainName(id),
+            nodes.getNodeAddress(id),
+            nodes.getNodePort(id),
+            nodes.getNodePublicKey(id)
         ]);
         nodeList.push({
-            id: 0,
+            id,
             ip,
             domainName,
             nodeAddress,

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -70,11 +70,6 @@ async function fetchNodes() {
     const schainsInternal = await skaleManagerInstance.getContract("SchainsInternal") as unknown as ISchainsInternal;
     const nodeIds = await schainsInternal.getNodesInGroup(mirageChainHash);
     const nodeIdsSorted = nodeIds.map(Number).sort((a, b) => a - b);
-    for (let i = 0; i < nodeIdsSorted.length; i++) {
-        if (nodeIdsSorted[i] !== i) {
-            throw new Error(`Node IDs are not consecutive from 0 to n. Expected ${i}, but found ${nodeIds[i]}`);
-        }
-    }
     const nodeList: INodes.NodeStruct[] = [];
     for (const id of nodeIdsSorted) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -70,17 +70,20 @@ async function fetchNodes() {
     const schainsInternal = await skaleManagerInstance.getContract("SchainsInternal") as unknown as ISchainsInternal;
     const nodeIds = await schainsInternal.getNodesInGroup(mirageChainHash);
     const nodeIdsSorted = nodeIds.map(Number).sort((a, b) => a - b);
+    if (nodeIdsSorted.includes(0)) {
+        throw new Error("Node IDs cannot contain 0");
+    }
     const nodeList: INodes.NodeStruct[] = [];
-    for (const id of nodeIdsSorted) {
+    for (const nodeId of nodeIdsSorted) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
-            nodes.getNodeIP(id),
-            nodes.getNodeDomainName(id),
-            nodes.getNodeAddress(id),
-            nodes.getNodePort(id),
-            nodes.getNodePublicKey(id)
+            nodes.getNodeIP(nodeId),
+            nodes.getNodeDomainName(nodeId),
+            nodes.getNodeAddress(nodeId),
+            nodes.getNodePort(nodeId),
+            nodes.getNodePublicKey(nodeId)
         ]);
         nodeList.push({
-            id,
+            id: nodeId,
             ip,
             domainName,
             nodeAddress,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "0.1.0-develop.73",
+    "@skalenetwork/professional-interfaces": "0.1.0-improve-function-naming.0",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.2.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/professional-interfaces": "0.1.0-improve-function-naming.0",
+    "@skalenetwork/professional-interfaces": "0.1.0-develop.74",
     "@skalenetwork/skale-contracts-ethers-v6": "^1.0.2-develop.61",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.42",

--- a/scripts/test_deploy.sh
+++ b/scripts/test_deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+// Cspell:words hoodi
 
 set -e
 export MAINNET_ENDPOINT="http://hoodi-qa-geth.skalenodes.com:8545"

--- a/scripts/test_deploy.sh
+++ b/scripts/test_deploy.sh
@@ -2,8 +2,12 @@
 // Cspell:words hoodi
 
 set -e
-export MAINNET_ENDPOINT="http://hoodi-qa-geth.skalenodes.com:8545"
-export CHAIN_NAME="mirage-qa-hoodi-1"
-export TARGET="0x5ef7849BF607Cbdb1f48cA82E38Fb567c7A77316"
+if [ -n "$INFURA_API_TOKEN" ]; then
+    export MAINNET_ENDPOINT="https://mainnet.infura.io/v3/${INFURA_API_TOKEN}"
+else
+    export MAINNET_ENDPOINT="https://eth.llamarpc.com"
+fi
+export CHAIN_NAME="affectionate-immediate-pollux"
+export TARGET="production"
 
 yarn hardhat run migrations/deploy.ts

--- a/scripts/test_deploy.sh
+++ b/scripts/test_deploy.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-// Cspell:words hoodi
 
 set -e
 if [ -n "$INFURA_API_TOKEN" ]; then

--- a/scripts/test_deploy.sh
+++ b/scripts/test_deploy.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -n "$INFURA_API_TOKEN" ]; then
-    export MAINNET_ENDPOINT="https://mainnet.infura.io/v3/${INFURA_API_TOKEN}"
-else
-    export MAINNET_ENDPOINT="https://eth.llamarpc.com"
-fi
-export CHAIN_NAME="affectionate-immediate-pollux"
-export TARGET="production"
+export MAINNET_ENDPOINT="http://hoodi-qa-geth.skalenodes.com:8545"
+export CHAIN_NAME="mirage-qa-hoodi-1"
+export TARGET="0x5ef7849BF607Cbdb1f48cA82E38Fb567c7A77316"
 
 yarn hardhat run migrations/deploy.ts

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -67,9 +67,9 @@ describe("Nodes", function () {
 
         expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
 
-        expect(await nodesContract.getActiveNodesIds()).to.include(nodeId);
+        expect(await nodesContract.getActiveNodeIds()).to.include(nodeId);
         expect(await nodesContract.activeNodeExists(nodeId)).to.eql(true);
-        const passiveNodeIds = await nodesContract.getPassiveNodesIds();
+        const passiveNodeIds = await nodesContract.getPassiveNodeIds();
         expect(passiveNodeIds.length).to.eql(0);
 
     });
@@ -77,20 +77,20 @@ describe("Nodes", function () {
     it("should register Passive Nodes", async () => {
 
         await nodesContract.registerPassiveNode(MOCK_IPV6_BYTES, 8000);
-        const [passiveNodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [passiveNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
         const passiveNode = await nodesContract.getNode(passiveNodeId);
         expect(passiveNode.id).to.equal(passiveNodeId);
         expect(passiveNode.port).to.equal(8000n);
         expect(Buffer.from(getBytes(passiveNode.ip))).to.eql(MOCK_IPV6_BYTES);
         expect(passiveNode.nodeAddress).to.equal(deployer.address);
-        expect(await nodesContract.getPassiveNodesIdsForAddress(deployer.address)).to.include(passiveNodeId);
+        expect(await nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.include(passiveNodeId);
 
         await nodesContract.connect(user1).registerPassiveNode(MOCK_IP_2_BYTES, 8000);
 
-        const nodesDeployer = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
-        const nodesUser1 = await nodesContract.getPassiveNodesIdsForAddress(user1.address);
+        const nodesDeployer = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
+        const nodesUser1 = await nodesContract.getPassiveNodeIdsForAddress(user1.address);
 
-        const allPassiveNodeIds = await nodesContract.getPassiveNodesIds();
+        const allPassiveNodeIds = await nodesContract.getPassiveNodeIds();
         expect(nodesDeployer.length).to.eql(1);
         expect(nodesUser1.length).to.eql(1);
         expect(allPassiveNodeIds.length).to.eql(2);
@@ -104,7 +104,7 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
-        await expect(nodesContract.getPassiveNodesIdsForAddress(deployer.address))
+        await expect(nodesContract.getPassiveNodeIdsForAddress(deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
     });
 
@@ -250,7 +250,7 @@ describe("Nodes", function () {
 
     it("should allow only Node owner to request Node address change", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [nodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [nodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await expect(nodesContract.connect(user1).requestChangeOwner(nodeId, user1.address))
         .to.be.reverted;
@@ -262,7 +262,7 @@ describe("Nodes", function () {
 
     it("should not allow passive nodes to request active node's addresses", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [firstNodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [firstNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await nodesContract.connect(user1).registerNode(MOCK_IP_1_BYTES, user1PubKey, 8000);
 
@@ -272,7 +272,7 @@ describe("Nodes", function () {
 
     it("should allow only new Node owner to submit Node address change", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [nodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [nodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await nodesContract.requestChangeOwner(nodeId, user1.address);
 
@@ -286,7 +286,7 @@ describe("Nodes", function () {
 
     it("should free an address after no passive node has it", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [nodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [nodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await nodesContract.requestChangeOwner(nodeId, user1.address);
 
@@ -308,7 +308,7 @@ describe("Nodes", function () {
 
     it("should block address change confirmation if address is taken", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [nodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [nodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await nodesContract.requestChangeOwner(nodeId, user1.address);
 
@@ -337,7 +337,7 @@ describe("Nodes", function () {
         // deployer owns 2 passive nodes
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
         await nodesContract.registerPassiveNode(MOCK_IP_1_BYTES, 8000);
-        const [firstNodeId, secondNodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [firstNodeId, secondNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         // Fails, active node addresses must be unique
         await expect(nodesContract.registerNode(MOCK_IP_2_BYTES, deployerPubKey, 8000))
@@ -369,7 +369,7 @@ describe("Nodes", function () {
 
     it("should revert when passive node was already assigned to the new address", async () => {
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
-        const [firstNodeId] = await nodesContract.getPassiveNodesIdsForAddress(deployer.address);
+        const [firstNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
 
         await nodesContract.requestChangeOwner(firstNodeId, deployer.address);
 

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -45,7 +45,7 @@ const generateRandomNodes = async (initialNumberOfNodes?: number) => {
             value: nodeBalance
         });
         nodesData.push({
-            id: 0,
+            id: i,
             ip: getIp(),
             domainName: `d2-${i}.skale`,
             nodeAddress: wallet.address,

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -38,7 +38,7 @@ const generateRandomNodes = async (initialNumberOfNodes?: number) => {
     const [owner] = await ethers.getSigners();
     initialNumberOfNodes = initialNumberOfNodes || numberOfNodes;
     const nodesData: NodeData[] = [];
-    for (let i = 0; i < initialNumberOfNodes; ++i) {
+    for (let i = 1; i <= initialNumberOfNodes; ++i) {
         const wallet = Wallet.createRandom().connect(ethers.provider) as HDNodeWallet;
         await owner.sendTransaction({
             to: wallet.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:0.1.0-improve-function-naming.0":
-  version: 0.1.0-improve-function-naming.0
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-improve-function-naming.0"
-  checksum: 10c0/5e5949ce09659372b7326f0be5759f9db1168a176704c4d5a3e30524929ded195ac7265a1bf553c7a23c189e71820bfd8abdc24ee4527fb98b4d2ceb9ba148c0
+"@skalenetwork/professional-interfaces@npm:0.1.0-develop.74":
+  version: 0.1.0-develop.74
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-develop.74"
+  checksum: 10c0/b8de6716737eb21d28f57f84248b0b368da531990b37c798dfdad2961f4e9db13e81849e2600a8fb848021516c1372564d346a8880d73e79a6d2c81c63a43480
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:0.1.0-improve-function-naming.0"
+    "@skalenetwork/professional-interfaces": "npm:0.1.0-develop.74"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/professional-interfaces@npm:0.1.0-develop.73":
-  version: 0.1.0-develop.73
-  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-develop.73"
-  checksum: 10c0/adef2fdcd0205687c30089d1bb7b67cfef3d5537d61f7cecd759b6089c9fbe9a55d53aa417818f2d0dcbd05e4406f3ae2219a7fe9b9da8437068b8f8e4bb0718
+"@skalenetwork/professional-interfaces@npm:0.1.0-improve-function-naming.0":
+  version: 0.1.0-improve-function-naming.0
+  resolution: "@skalenetwork/professional-interfaces@npm:0.1.0-improve-function-naming.0"
+  checksum: 10c0/5e5949ce09659372b7326f0be5759f9db1168a176704c4d5a3e30524929ded195ac7265a1bf553c7a23c189e71820bfd8abdc24ee4527fb98b4d2ceb9ba148c0
   languageName: node
   linkType: hard
 
@@ -6713,7 +6713,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.2.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/professional-interfaces": "npm:0.1.0-develop.73"
+    "@skalenetwork/professional-interfaces": "npm:0.1.0-improve-function-naming.0"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:^1.0.2-develop.61"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.42"


### PR DESCRIPTION
Changed order of registering nodes during initialization
Requirements for skale-manager boot:
- create 23 nodes with node indexes from 0 to 22
- put node with index 0 into maintenance mode
- create schain, it should include nodes with indexes from 1 to 22
