### PR TITLE
Add functionality to delete Nodes

### DIFF
--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -34,9 +34,9 @@ import { INodes, NodeId } from "@skalenetwork/fair-manager-interfaces/INodes.sol
 import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 import { Duration, IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
 import { Fair } from "@skalenetwork/fair-manager-interfaces/units.sol";
-
 import { TypedSet } from "./structs/typed/TypedSet.sol";
 import { G2Operations } from "./utils/fieldOperations/G2Operations.sol";
+import { FundLibrary } from "./utils/Fund.sol";
 import { PoolLibrary } from "./utils/Pool.sol";
 import { Precompiled } from "./utils/Precompiled.sol";
 import { IRandom, Random } from "./utils/Random.sol";
@@ -168,11 +168,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
 
     function nodeRemoved(NodeId node) external override restricted {
         _setIneligible(node);
-
     }
 
     function nodeWhitelisted(NodeId node) external override restricted {
-        if (staking.getNodeShare(node) > 0 && status.isHealthy(node)) {
+        if (staking.getNodeTotalStake(node) > FundLibrary.ZERO_FAIR && status.isHealthy(node)) {
             _setEligible(node);
         }
     }
@@ -188,7 +187,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
                 _shareToWeight(staking.getNodeShare(node))
             );
         } else {
-            if (status.isWhitelisted(node) && Fair.unwrap(staking.getNodeTotalStake(node)) > 0) {
+            if (status.isWhitelisted(node) && staking.getNodeTotalStake(node) > FundLibrary.ZERO_FAIR) {
                 _setEligible(node);
                 _pool.moveToFront(
                     node,

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -33,7 +33,6 @@ import { DkgId, IDkg } from "@skalenetwork/fair-manager-interfaces/IDkg.sol";
 import { INodes, NodeId } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 import { Duration, IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
-import { Fair } from "@skalenetwork/fair-manager-interfaces/units.sol";
 import { TypedSet } from "./structs/typed/TypedSet.sol";
 import { G2Operations } from "./utils/fieldOperations/G2Operations.sol";
 import { FundLibrary } from "./utils/Fund.sol";

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -33,6 +33,7 @@ import { DkgId, IDkg } from "@skalenetwork/fair-manager-interfaces/IDkg.sol";
 import { INodes, NodeId } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 import { Duration, IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
+import { Fair } from "@skalenetwork/fair-manager-interfaces/units.sol";
 
 import { TypedSet } from "./structs/typed/TypedSet.sol";
 import { G2Operations } from "./utils/fieldOperations/G2Operations.sol";
@@ -187,7 +188,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
                 _shareToWeight(staking.getNodeShare(node))
             );
         } else {
-            if (status.isWhitelisted(node) && staking.getNodeShare(node) > 0) {
+            if (status.isWhitelisted(node) && Fair.unwrap(staking.getNodeTotalStake(node)) > 0) {
                 _setEligible(node);
                 _pool.moveToFront(
                     node,
@@ -314,11 +315,17 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     function _setEligible(NodeId node) private {
         _pool.add(node);
         emit NodeBecomesEligible(node);
+        if (!staking.isNodeEnabled(node)) {
+            staking.enable(node);
+        }
     }
 
     function _setIneligible(NodeId node) private {
         if (_pool.remove(node)) {
             emit NodeLosesEligibility(node);
+        }
+        if (staking.isNodeEnabled(node)) {
+            staking.disable(node);
         }
     }
 

--- a/contracts/FairAccessManager.sol
+++ b/contracts/FairAccessManager.sol
@@ -30,6 +30,7 @@ contract FairAccessManager is AccessManagerUpgradeable {
     uint64 public constant NODES_ROLE = 1;
     uint64 public constant STATUS_ROLE = 2;
     uint64 public constant STAKING_ROLE = 3;
+    uint64 public constant COMMITEE_ROLE = 4;
 
     function initialize(address initialAdmin) public initializer override {
         __AccessManager_init(initialAdmin);

--- a/contracts/FairAccessManager.sol
+++ b/contracts/FairAccessManager.sol
@@ -30,7 +30,7 @@ contract FairAccessManager is AccessManagerUpgradeable {
     uint64 public constant NODES_ROLE = 1;
     uint64 public constant STATUS_ROLE = 2;
     uint64 public constant STAKING_ROLE = 3;
-    uint64 public constant COMMITEE_ROLE = 4;
+    uint64 public constant COMMITTEE_ROLE = 4;
 
     function initialize(address initialAdmin) public initializer override {
         __AccessManager_init(initialAdmin);

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -29,6 +29,8 @@ import {
     INodes,
     NodeId
 } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
+import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
+import { IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
 
 import { TypedMap } from "./structs/typed/TypedMap.sol";
 import { TypedSet } from "./structs/typed/TypedSet.sol";
@@ -76,6 +78,8 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     TypedSet.NodeIdSet private _activeNodeIds;
 
     error NodeIsInCommittee(NodeId nodeId);
+    error NodeIsNotActiveNode(NodeId nodeId);
+    error NodeHasDelegations(NodeId nodeId);
     error AddressIsAlreadyAssignedToNode(address nodeAddress);
     error AddressIsNotAssignedToAnyNode(address nodeAddress);
     error PassiveNodeAlreadyExistsForAddress(address nodeAddress, NodeId nodeId);
@@ -171,6 +175,21 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             publicKey: publicKey
         });
         committeeContract.nodeCreated(nextNodeId);
+    }
+
+    function deleteNode(
+        NodeId nodeId
+    )
+        external
+        override
+        nodeExists(nodeId)
+        onlyNodeOwner(nodeId)
+    {
+        _deleteNode(nodeId);
+    }
+
+    function deleteNodeByFoundation(NodeId nodeId) external override nodeExists(nodeId) restricted {
+        _deleteNode(nodeId);
     }
 
     function requestChangeOwner(
@@ -308,12 +327,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     }
 
     function getNodeId(address nodeAddress) external view override returns (NodeId nodeId) {
-        // Getter for active node
         require(
             _isAddressOfActiveNode(nodeAddress),
             AddressIsNotAssignedToAnyNode(nodeAddress)
         );
-
         nodeId = _activeNodesAddressToId.get(nodeAddress);
     }
 
@@ -373,6 +390,51 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         emit NodeRegistered(nodeId, nodeAddress, ip, port);
     }
 
+    function _deleteNode(NodeId id) private {
+        if (_isActiveNode(id)) {
+            _deleteActiveNode(id);
+        }
+        else {
+            _deletePassiveNode(id);
+        }
+        Node storage node = nodes[id];
+        assert(_usedIps.remove(keccak256(node.ip)));
+        if (bytes(node.domainName).length > 0) {
+            bytes32 newName = keccak256(abi.encodePacked(node.domainName));
+            assert(_usedDomainNames.remove(newName));
+        }
+        emit NodeDeleted(id, node.nodeAddress, node.ip, node.port);
+        delete nodes[id];
+    }
+
+    function _deletePassiveNode(NodeId id) private {
+        Node storage node = nodes[id];
+        assert(_passiveNodeIds.remove(id));
+        assert(_passiveNodeAddresses.remove(node.nodeAddress));
+        assert(_passiveNodeIdByAddress.remove(node.nodeAddress, id));
+        delete ownerChangeRequests[node.id];
+    }
+
+    function _deleteActiveNode(
+        NodeId id
+    )
+        private
+        nodeNotInCurrentOrNextCommittee(id)
+    {
+        IStaking stakingContract = IStaking(committeeContract.staking());
+        IStatus statusContract = IStatus(committeeContract.status());
+        require(stakingContract.getNodeShare(id) == 0, NodeHasDelegations(id));
+        if (statusContract.isWhitelisted(id)) {
+            statusContract.nodeRemoved(id);
+        }
+        committeeContract.nodeRemoved(id);
+        Node storage node = nodes[id];
+
+        assert(_activeNodeIds.remove(id));
+        assert(_activeNodesAddressToId.remove(node.nodeAddress));
+
+    }
+
     function _addPassiveNodeId(NodeId nodeId) private {
         assert(_passiveNodeIds.add(nodeId));
     }
@@ -420,6 +482,14 @@ contract Nodes is AccessManagedUpgradeable, INodes {
                 domainName: initNode.domainName,
                 publicKey: initNode.publicKey
             });
+            if (bytes(initNode.domainName).length > 0){
+                bytes32 newName = keccak256(abi.encodePacked(initNode.domainName));
+                require(
+                    _usedDomainNames.add(newName),
+                    DomainNameAlreadyTaken(initNode.domainName)
+                );
+
+            }
         }
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -391,32 +391,33 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     }
 
     function _deleteNode(NodeId id) private {
-        if (_isActiveNode(id)) {
-            _deleteActiveNode(id);
-        }
-        else {
-            _deletePassiveNode(id);
-        }
         Node storage node = nodes[id];
         assert(_usedIps.remove(keccak256(node.ip)));
         if (bytes(node.domainName).length > 0) {
             bytes32 newName = keccak256(abi.encodePacked(node.domainName));
             assert(_usedDomainNames.remove(newName));
         }
+        address nodeOwner = node.nodeAddress;
         emit NodeDeleted(id, node.nodeAddress, node.ip, node.port);
         delete nodes[id];
+        if (_isActiveNode(id)) {
+            _deleteActiveNode(id, nodeOwner);
+        }
+        else {
+            _deletePassiveNode(id, nodeOwner);
+        }
     }
 
-    function _deletePassiveNode(NodeId id) private {
-        Node storage node = nodes[id];
+    function _deletePassiveNode(NodeId id, address nodeAddress) private {
         assert(_passiveNodeIds.remove(id));
-        assert(_passiveNodeAddresses.remove(node.nodeAddress));
-        assert(_passiveNodeIdByAddress.remove(node.nodeAddress, id));
-        delete ownerChangeRequests[node.id];
+        assert(_passiveNodeAddresses.remove(nodeAddress));
+        assert(_passiveNodeIdByAddress.remove(nodeAddress, id));
+        delete ownerChangeRequests[id];
     }
 
     function _deleteActiveNode(
-        NodeId id
+        NodeId id,
+        address nodeAddress
     )
         private
         nodeNotInCurrentOrNextCommittee(id)
@@ -424,15 +425,12 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         IStaking stakingContract = IStaking(committeeContract.staking());
         IStatus statusContract = IStatus(committeeContract.status());
         require(stakingContract.getNodeShare(id) == 0, NodeHasDelegations(id));
+        assert(_activeNodeIds.remove(id));
+        assert(_activeNodesAddressToId.remove(nodeAddress));
         if (statusContract.isWhitelisted(id)) {
             statusContract.nodeRemoved(id);
         }
         committeeContract.nodeRemoved(id);
-        Node storage node = nodes[id];
-
-        assert(_activeNodeIds.remove(id));
-        assert(_activeNodesAddressToId.remove(node.nodeAddress));
-
     }
 
     function _addPassiveNodeId(NodeId nodeId) private {

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -396,12 +396,12 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_usedDomainNames.remove(newName));
         }
         address nodeOwner = node.nodeAddress;
-        emit NodeDeleted(id, nodeOwner, node.ip, node.port);
         delete nodes[id];
         if (_isActiveNode(id)) {
             IStatus statusContract = IStatus(committeeContract.status());
             assert(_activeNodeIds.remove(id));
             assert(_activeNodesAddressToId.remove(nodeOwner));
+            emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
             if (statusContract.isWhitelisted(id)) {
                 statusContract.nodeRemoved(id);
             }
@@ -412,6 +412,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_passiveNodeAddresses.remove(nodeOwner));
             assert(_passiveNodeIdByAddress.remove(nodeOwner, id));
             delete ownerChangeRequests[id];
+            emit PassiveNodeDeleted(id, nodeOwner, node.ip, node.port);
         }
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -77,7 +77,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     TypedSet.NodeIdSet private _activeNodeIds;
 
     error NodeIsInCommittee(NodeId nodeId);
-    error NodeIsNotActiveNode(NodeId nodeId);
     error AddressIsAlreadyAssignedToNode(address nodeAddress);
     error AddressIsNotAssignedToAnyNode(address nodeAddress);
     error PassiveNodeAlreadyExistsForAddress(address nodeAddress, NodeId nodeId);
@@ -376,6 +375,14 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         _addActiveNodeId(nodeId);
         _setActiveNodeIdForAddress(nodeAddress, nodeId);
 
+        if (bytes(domainName).length > 0){
+            bytes32 hashedName = keccak256(abi.encodePacked(domainName));
+            require(
+                _usedDomainNames.add(hashedName),
+                DomainNameAlreadyTaken(domainName)
+            );
+        }
+
         nodes[nodeId] = Node({
             id: nodeId,
             publicKey: publicKey,
@@ -402,9 +409,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_activeNodeIds.remove(id));
             assert(_activeNodesAddressToId.remove(nodeOwner));
             emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
-            if (statusContract.isWhitelisted(id)) {
-                statusContract.nodeRemoved(id);
-            }
+            statusContract.nodeRemoved(id);
             committeeContract.nodeRemoved(id);
         }
         else {
@@ -463,14 +468,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
                 domainName: initNode.domainName,
                 publicKey: initNode.publicKey
             });
-            if (bytes(initNode.domainName).length > 0){
-                bytes32 newName = keccak256(abi.encodePacked(initNode.domainName));
-                require(
-                    _usedDomainNames.add(newName),
-                    DomainNameAlreadyTaken(initNode.domainName)
-                );
-
-            }
         }
     }
 

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -29,7 +29,6 @@ import {
     INodes,
     NodeId
 } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
-import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 import { IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
 
 import { TypedMap } from "./structs/typed/TypedMap.sol";
@@ -79,7 +78,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
     error NodeIsInCommittee(NodeId nodeId);
     error NodeIsNotActiveNode(NodeId nodeId);
-    error NodeHasDelegations(NodeId nodeId);
     error AddressIsAlreadyAssignedToNode(address nodeAddress);
     error AddressIsNotAssignedToAnyNode(address nodeAddress);
     error PassiveNodeAlreadyExistsForAddress(address nodeAddress, NodeId nodeId);
@@ -422,9 +420,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         private
         nodeNotInCurrentOrNextCommittee(id)
     {
-        IStaking stakingContract = IStaking(committeeContract.staking());
         IStatus statusContract = IStatus(committeeContract.status());
-        require(stakingContract.getNodeShare(id) == 0, NodeHasDelegations(id));
         assert(_activeNodeIds.remove(id));
         assert(_activeNodesAddressToId.remove(nodeAddress));
         if (statusContract.isWhitelisted(id)) {

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -388,7 +388,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         emit NodeRegistered(nodeId, nodeAddress, ip, port);
     }
 
-    function _deleteNode(NodeId id) private {
+    function _deleteNode(NodeId id) private nodeNotInCurrentOrNextCommittee(id) {
         Node storage node = nodes[id];
         assert(_usedIps.remove(keccak256(node.ip)));
         if (bytes(node.domainName).length > 0) {
@@ -396,37 +396,23 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_usedDomainNames.remove(newName));
         }
         address nodeOwner = node.nodeAddress;
-        emit NodeDeleted(id, node.nodeAddress, node.ip, node.port);
+        emit NodeDeleted(id, nodeOwner, node.ip, node.port);
         delete nodes[id];
         if (_isActiveNode(id)) {
-            _deleteActiveNode(id, nodeOwner);
+            IStatus statusContract = IStatus(committeeContract.status());
+            assert(_activeNodeIds.remove(id));
+            assert(_activeNodesAddressToId.remove(nodeOwner));
+            if (statusContract.isWhitelisted(id)) {
+                statusContract.nodeRemoved(id);
+            }
+            committeeContract.nodeRemoved(id);
         }
         else {
-            _deletePassiveNode(id, nodeOwner);
+            assert(_passiveNodeIds.remove(id));
+            assert(_passiveNodeAddresses.remove(nodeOwner));
+            assert(_passiveNodeIdByAddress.remove(nodeOwner, id));
+            delete ownerChangeRequests[id];
         }
-    }
-
-    function _deletePassiveNode(NodeId id, address nodeAddress) private {
-        assert(_passiveNodeIds.remove(id));
-        assert(_passiveNodeAddresses.remove(nodeAddress));
-        assert(_passiveNodeIdByAddress.remove(nodeAddress, id));
-        delete ownerChangeRequests[id];
-    }
-
-    function _deleteActiveNode(
-        NodeId id,
-        address nodeAddress
-    )
-        private
-        nodeNotInCurrentOrNextCommittee(id)
-    {
-        IStatus statusContract = IStatus(committeeContract.status());
-        assert(_activeNodeIds.remove(id));
-        assert(_activeNodesAddressToId.remove(nodeAddress));
-        if (statusContract.isWhitelisted(id)) {
-            statusContract.nodeRemoved(id);
-        }
-        committeeContract.nodeRemoved(id);
     }
 
     function _addPassiveNodeId(NodeId nodeId) private {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -116,7 +116,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         require(_stakedNodes[msg.sender].contains(node), ZeroStakeToNode(node));
         require(!committee.isNodeInCurrentOrNextCommittee(node), NodeInCommittee(node));
 
-        bool nodeIsEnabled = !_disabledNodesBalances.contains(node);
+        bool nodeIsEnabled = isNodeEnabled(node);
         if (nodeIsEnabled) {
             Fair balance = _getTotalBalance();
             _nodesFunds[node].remove(
@@ -137,6 +137,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
                 value
             );
             assert(!_disabledNodesBalances.set(node, nodeFundBalance - value));
+            totalDisabled = totalDisabled - value;
         }
 
         if (_nodesFunds[node].credits[FundLibrary.addressToHolder(msg.sender)] == FundLibrary.ZERO_CREDIT) {
@@ -169,7 +170,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     function stake(NodeId node) external payable override {
         require(msg.value > 0, ZeroAmount());
         require(nodes.activeNodeExists(node), Nodes.NodeDoesNotExist(node));
-        bool nodeIsEnabled = !_disabledNodesBalances.contains(node);
+        bool nodeIsEnabled = isNodeEnabled(node);
         Fair amount = Fair.wrap(msg.value);
         Fair balance = _getTotalBalance() - amount;
         if (nodeIsEnabled) {
@@ -191,6 +192,9 @@ contract Staking is AccessManagedUpgradeable, IStaking {
                 amount
             );
             assert(!_disabledNodesBalances.set(node, nodeFundBalance + amount));
+            unchecked {
+                totalDisabled = totalDisabled + amount;
+            }
         }
         if(_stakedNodes[msg.sender].add(node)) {
             emit StakedToNewNode(msg.sender, node);
@@ -203,7 +207,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     }
 
     function getNodeShare(NodeId node) external view override returns (uint256 share) {
-        if (_disabledNodesBalances.contains(node)) {
+        if (!isNodeEnabled(node)) {
             return 0;
         }
         return Credit.unwrap(_rootFund.credits[FundLibrary.nodeToHolder(node)]);
@@ -221,12 +225,8 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         return getStakedNodesFor(msg.sender);
     }
 
-    function isNodeEnabled(NodeId node) external view override returns (bool enabled) {
-        return !_disabledNodesBalances.contains(node);
-    }
-
     function getNodeTotalStake(NodeId node) external view override returns (Fair amount) {
-        if (_disabledNodesBalances.contains(node)) {
+        if (!isNodeEnabled(node)) {
             return _disabledNodesBalances.get(node);
         }
         Fair balance = _getTotalBalance();
@@ -238,7 +238,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     function claimFee(address payable to, Fair amount) public override {
         NodeId node = nodes.getNodeId(msg.sender);
         Fair balance = _getTotalBalance();
-        bool nodeIsEnabled = !_disabledNodesBalances.contains(node);
+        bool nodeIsEnabled = isNodeEnabled(node);
         if (nodeIsEnabled) {
             _nodesFunds[node].claimFee(
                 _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node)),
@@ -264,8 +264,12 @@ contract Staking is AccessManagedUpgradeable, IStaking {
         to.sendValue(Fair.unwrap(amount));
     }
 
+    function isNodeEnabled(NodeId node) public view override returns (bool enabled) {
+        return !_disabledNodesBalances.contains(node);
+    }
+
     function getEarnedFeeAmount(NodeId node) public view override returns (Fair amount) {
-        if (_disabledNodesBalances.contains(node)) {
+        if (!isNodeEnabled(node)) {
             return _nodesFunds[node].getEarnedFee(_disabledNodesBalances.get(node));
         }
         return _nodesFunds[node].getEarnedFee(
@@ -287,7 +291,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
 
     function getStakedToNodeAmountFor(NodeId node, address holder) public view override returns (Fair amount) {
         Fair nodeBalance;
-        if (_disabledNodesBalances.contains(node)) {
+        if (!isNodeEnabled(node)) {
             nodeBalance = _disabledNodesBalances.get(node);
         } else {
             nodeBalance = _rootFund.getBalance(_getTotalBalance(), FundLibrary.nodeToHolder(node));

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -97,6 +97,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     }
 
     function enable(NodeId node) external override restricted {
+        require(nodes.activeNodeExists(node), Nodes.NodeDoesNotExist(node));
         (bool wasDisabled, Fair value) = _disabledNodesBalances.tryGet(node);
         require(wasDisabled, NodeIsNotDisabled(node));
         Fair balance = _getTotalBalance();
@@ -112,7 +113,6 @@ contract Staking is AccessManagedUpgradeable, IStaking {
 
     function retrieve(NodeId node, Fair value) external override {
         require(value > FundLibrary.ZERO_FAIR, ZeroAmount());
-        require(nodes.activeNodeExists(node), Nodes.NodeDoesNotExist(node));
         require(_stakedNodes[msg.sender].contains(node), ZeroStakeToNode(node));
         require(!committee.isNodeInCurrentOrNextCommittee(node), NodeInCommittee(node));
 
@@ -219,6 +219,18 @@ contract Staking is AccessManagedUpgradeable, IStaking {
 
     function getStakedNodes() external view override returns (NodeId[] memory stakedNodes) {
         return getStakedNodesFor(msg.sender);
+    }
+
+    function isNodeEnabled(NodeId node) external view override returns (bool enabled) {
+        return !_disabledNodesBalances.contains(node);
+    }
+
+    function getNodeTotalStake(NodeId node) external view override returns (Fair amount) {
+        if (_disabledNodesBalances.contains(node)) {
+            return _disabledNodesBalances.get(node);
+        }
+        Fair balance = _getTotalBalance();
+        amount = _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node));
     }
 
     // Public

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -192,9 +192,7 @@ contract Staking is AccessManagedUpgradeable, IStaking {
                 amount
             );
             assert(!_disabledNodesBalances.set(node, nodeFundBalance + amount));
-            unchecked {
-                totalDisabled = totalDisabled + amount;
-            }
+            totalDisabled = totalDisabled + amount;
         }
         if(_stakedNodes[msg.sender].add(node)) {
             emit StakedToNewNode(msg.sender, node);

--- a/contracts/Status.sol
+++ b/contracts/Status.sol
@@ -90,7 +90,10 @@ contract Status is AccessManagedUpgradeable, IStatus {
     }
 
     function nodeRemoved(NodeId nodeId) external override restricted {
-        require(_whitelist.remove(nodeId), NodeNotWhitelisted(nodeId));
+        if(_whitelist.contains(nodeId)){
+            assert(_whitelist.remove(nodeId));
+        }
+        delete lastHeartbeatTimestamp[nodeId];
     }
 
     function getNodesEligibleForCommittee() external view override returns (NodeId[] memory nodeIds) {

--- a/contracts/Status.sol
+++ b/contracts/Status.sol
@@ -89,6 +89,10 @@ contract Status is AccessManagedUpgradeable, IStatus {
         committee.nodeBlacklisted(nodeId);
     }
 
+    function nodeRemoved(NodeId nodeId) external override restricted {
+        require(_whitelist.remove(nodeId), NodeNotWhitelisted(nodeId));
+    }
+
     function getNodesEligibleForCommittee() external view override returns (NodeId[] memory nodeIds) {
 
         uint256 whitelistedLength = _whitelist.length();

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -261,28 +261,21 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
 
     let response = await accessManager.setTargetFunctionRole(
         await ethers.resolveAddress(committee),
-        [committee.interface.getFunction("nodeCreated").selector],
+        [
+            committee.interface.getFunction("nodeCreated").selector,
+            committee.interface.getFunction("nodeRemoved").selector
+        ],
         await accessManager.NODES_ROLE()
     );
     await response.wait();
 
     response = await accessManager.setTargetFunctionRole(
         await ethers.resolveAddress(committee),
-        [committee.interface.getFunction("nodeBlacklisted").selector],
-        await accessManager.STATUS_ROLE()
-    );
-    await response.wait();
-
-    response = await accessManager.setTargetFunctionRole(
-        await ethers.resolveAddress(committee),
-        [committee.interface.getFunction("nodeWhitelisted").selector],
-        await accessManager.STATUS_ROLE()
-    );
-    await response.wait();
-
-    response = await accessManager.setTargetFunctionRole(
-        await ethers.resolveAddress(committee),
-        [committee.interface.getFunction("processHeartbeat").selector],
+        [
+            committee.interface.getFunction("nodeBlacklisted").selector,
+            committee.interface.getFunction("nodeWhitelisted").selector,
+            committee.interface.getFunction("processHeartbeat").selector
+        ],
         await accessManager.STATUS_ROLE()
     );
     await response.wait();
@@ -291,6 +284,13 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
         await ethers.resolveAddress(committee),
         [committee.interface.getFunction("updateWeight").selector],
         await accessManager.STAKING_ROLE()
+    );
+    await response.wait();
+
+    response = await accessManager.setTargetFunctionRole(
+        await ethers.resolveAddress(status),
+        [status.interface.getFunction("nodeRemoved").selector],
+        await accessManager.NODES_ROLE()
     );
     await response.wait();
 
@@ -304,6 +304,7 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
 
     response = await accessManager.grantRole(await accessManager.STAKING_ROLE(), await ethers.resolveAddress(staking), 0n);
     await response.wait();
+
 }
 
 const verify = async (deployedContracts: DeployedContracts) => {

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -259,6 +259,7 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
 
     // set up roles
 
+    //Committee
     let response = await accessManager.setTargetFunctionRole(
         await ethers.resolveAddress(committee),
         [
@@ -287,6 +288,18 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
     );
     await response.wait();
 
+    //Staking
+    response = await accessManager.setTargetFunctionRole(
+        await ethers.resolveAddress(staking),
+        [
+            staking.interface.getFunction("disable").selector,
+            staking.interface.getFunction("enable").selector
+        ],
+        await accessManager.COMMITEE_ROLE()
+    );
+    await response.wait();
+
+    //Status
     response = await accessManager.setTargetFunctionRole(
         await ethers.resolveAddress(status),
         [status.interface.getFunction("nodeRemoved").selector],
@@ -305,6 +318,8 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
     response = await accessManager.grantRole(await accessManager.STAKING_ROLE(), await ethers.resolveAddress(staking), 0n);
     await response.wait();
 
+    response = await accessManager.grantRole(await accessManager.COMMITEE_ROLE(), await ethers.resolveAddress(committee), 0n);
+    await response.wait();
 }
 
 const verify = async (deployedContracts: DeployedContracts) => {

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -295,7 +295,7 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
             staking.interface.getFunction("disable").selector,
             staking.interface.getFunction("enable").selector
         ],
-        await accessManager.COMMITEE_ROLE()
+        await accessManager.COMMITTEE_ROLE()
     );
     await response.wait();
 
@@ -318,7 +318,7 @@ const setupRoles = async (deployedContracts: DeployedContracts) => {
     response = await accessManager.grantRole(await accessManager.STAKING_ROLE(), await ethers.resolveAddress(staking), 0n);
     await response.wait();
 
-    response = await accessManager.grantRole(await accessManager.COMMITEE_ROLE(), await ethers.resolveAddress(committee), 0n);
+    response = await accessManager.grantRole(await accessManager.COMMITTEE_ROLE(), await ethers.resolveAddress(committee), 0n);
     await response.wait();
 }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.7",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.9",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.9",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.10",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.11",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.80",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.10",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.11",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.79",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-remove-node.7",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -82,10 +82,13 @@ describe("Committee", () => {
 
     it("should select committee", async function () {
         this.timeout(600000); // 10 minutes timeout. DKG requires a lot of time
-        const {committee, dkg, nodesData} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee, dkg, nodesData, status, staking} = await whitelistedAndStakedAndHealthyNodes();
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();
         const nextCommitteeIndex = activeCommitteeIndex + 1n;
-
+        for(const node of nodesData){
+            expect(await status.isHealthy(node.id)).to.be.eql(true);
+            expect(await staking.getNodeShare(node.id)).to.be.greaterThan(0n);
+        }
         await committee.select();
 
         let nextCommittee = await committee.getCommittee(nextCommitteeIndex);

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -208,7 +208,9 @@ describe("Committee", () => {
     });
 
     it("should set transition delay", async () => {
-        const {committee, dkg, nodesData} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee, status, dkg, nodesData} = await whitelistedAndStakedNodes();
+        const subset = nodesData.slice(0, 5);
+        await sendHeartbeat(status, subset);
         const activeCommitteeIndex = await committee.getActiveCommitteeIndex();
         const nextCommitteeIndex = activeCommitteeIndex + 1n;
         const newTransitionDelay = 0xd2n;
@@ -386,7 +388,8 @@ describe("Committee", () => {
     });
 
     it("should emit proper error when there are eligible nodes but all of them are not healthy", async () => {
-        const {committee, status} = await whitelistedAndStakedAndHealthyNodes();
+        const {committee, status, nodesData} = await whitelistedAndStakedNodes();
+        await sendHeartbeat(status, nodesData.slice(0, Number(await committee.committeeSize())));
         await skipTime(await status.heartbeatInterval());
         await committee.select()
             .should.be.revertedWithCustomError(committee, "TooFewCandidates")

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { cleanDeployment, sendHeartbeat, whitelistedAndStakedNodes } from "./tools/fixtures";
-import { Nodes } from "../typechain-types";
+import { FairAccessManager, Nodes, Staking } from "../typechain-types";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -35,6 +35,8 @@ chai.use(chaiAsPromised)
 
 describe("Nodes", function () {
     let nodesContract: Nodes;
+    let accessManagerContract: FairAccessManager;
+    let stakingContract: Staking;
     let deployer: HardhatEthersSigner;
     let user1: HardhatEthersSigner;
     let user2: HardhatEthersSigner;
@@ -44,8 +46,10 @@ describe("Nodes", function () {
 
 
     beforeEach(async () => {
-        const {nodes} = await cleanDeployment();
+        const {nodes, accessManager, staking} = await cleanDeployment();
         nodesContract = nodes;
+        stakingContract = staking;
+        accessManagerContract = accessManager;
         [deployer, user1, user2] = await ethers.getSigners();
 
         [deployerPubKey, user1PubKey, user2PubKey] = await Promise.all(
@@ -93,6 +97,19 @@ describe("Nodes", function () {
         await expect(nodesContract.getNode(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
         expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeId);
         expect(await nodesContract.activeNodeExists(nodeId)).to.eql(false);
+    });
+
+    it("should not allow to enable a deleted Node", async () => {
+        await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey, 8000);
+        const nodeId = await nodesContract.getNodeId(deployer.address) as BigNumberish;
+        expect(await stakingContract.isNodeEnabled(nodeId)).to.be.eql(true);
+
+        await nodesContract.deleteNode(nodeId);
+
+        const response = await accessManagerContract.grantRole(await accessManagerContract.COMMITEE_ROLE(), deployer, 0n);
+        await response.wait();
+
+        await expect(stakingContract.enable(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
     });
 
     it("should not allow anyone other than Node owner or Foundation to delete nodes", async () => {

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -468,7 +468,7 @@ describe("Nodes", function () {
         await committee.setCommitteeSize(5); // to save resources
         await sendHeartbeat(status, nodesData.slice(0, 10)); // to save time
         await committee.select();
-        for(const node of nodesData) {
+        for(const node of nodesData.slice(0, 10)) {
             const nodeBlocked = await committee.isNodeInCurrentOrNextCommittee(node.id);
             if (nodeBlocked) {
                 await expect(nodes.connect(node.wallet).deleteNode(node.id))

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -74,6 +74,50 @@ describe("Nodes", function () {
 
     });
 
+    it("should register and delete Active Nodes", async () => {
+        await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey, 8000);
+        const nodeId = await nodesContract.getNodeId(deployer.address) as BigNumberish;
+        const node = await nodesContract.getNode(nodeId);
+        expect(node.id).to.equal(nodeId);
+        expect(node.port).to.equal(8000n);
+        expect(Buffer.from(getBytes(node.ip))).to.eql(MOCK_IP_0_BYTES);
+        expect(node.nodeAddress).to.equal(deployer.address);
+        expect(node.publicKey).to.eql(deployerPubKey);
+
+        expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
+        expect(await nodesContract.getActiveNodeIds()).to.include(nodeId);
+        expect(await nodesContract.activeNodeExists(nodeId)).to.eql(true);
+
+        await nodesContract.connect(deployer).deleteNode(nodeId);
+
+        await expect(nodesContract.getNode(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
+        expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeId);
+        expect(await nodesContract.activeNodeExists(nodeId)).to.eql(false);
+    });
+
+    it("should not allow anyone other than Node owner or Foundation to delete nodes", async () => {
+        await nodesContract.connect(user1).registerNode(MOCK_IP_0_BYTES, user1PubKey, 8000);
+        const nodeId = await nodesContract.getNodeId(user1.address) as BigNumberish;
+        await nodesContract.connect(user1).setDomainName(nodeId, MOCK_DOMAIN_NAME_0);
+        await expect(nodesContract.connect(deployer).deleteNode(nodeId)).to.be.revertedWithCustomError(nodesContract, "SenderIsNotNodeOwner");
+
+        await nodesContract.connect(user1).deleteNode(nodeId);
+        await expect(nodesContract.getNode(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
+        expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeId);
+        expect(await nodesContract.activeNodeExists(nodeId)).to.eql(false);
+
+        await nodesContract.connect(user1).registerNode(MOCK_IP_0_BYTES, user1PubKey, 8000);
+        const nodeIdV2 = await nodesContract.getNodeId(user1.address) as BigNumberish;
+        await nodesContract.connect(user1).setDomainName(nodeIdV2, MOCK_DOMAIN_NAME_0);
+
+        await expect(nodesContract.connect(user1).deleteNodeByFoundation(nodeIdV2)).to.be.reverted;
+        await nodesContract.connect(deployer).deleteNodeByFoundation(nodeIdV2);
+
+        await expect(nodesContract.getNode(nodeIdV2)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
+        expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeIdV2);
+        expect(await nodesContract.activeNodeExists(nodeIdV2)).to.eql(false);
+    });
+
     it("should register Passive Nodes", async () => {
 
         await nodesContract.registerPassiveNode(MOCK_IPV6_BYTES, 8000);
@@ -97,7 +141,28 @@ describe("Nodes", function () {
         expect(allPassiveNodeIds).to.eql(nodesDeployer.concat(nodesUser1));
     });
 
-    it("should revert when node does not exist", async () => {
+    it("should register and delete passive Nodes", async () => {
+        await nodesContract.registerPassiveNode(MOCK_IPV6_BYTES, 8000);
+        const [passiveNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
+        const passiveNode = await nodesContract.getNode(passiveNodeId);
+        expect(passiveNode.id).to.equal(passiveNodeId);
+        expect(passiveNode.port).to.equal(8000n);
+        expect(Buffer.from(getBytes(passiveNode.ip))).to.eql(MOCK_IPV6_BYTES);
+        expect(passiveNode.nodeAddress).to.equal(deployer.address);
+        expect(await nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.include(passiveNodeId);
+
+        await nodesContract.connect(deployer).deleteNode(passiveNodeId);
+        await expect(nodesContract.getNode(passiveNodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
+
+        await expect(nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.be
+        .revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
+
+        const allPassiveNodeIds = await nodesContract.getPassiveNodeIds();
+        expect(allPassiveNodeIds.length).to.eql(0);
+
+    });
+
+    it("getNode should revert when node does not exist", async () => {
         await expect(nodesContract.getNode(0))
         .to.be.reverted;
 
@@ -398,4 +463,27 @@ describe("Nodes", function () {
 
     });
 
+    it("should should not allow deleting node if node in current or next committee or has stake", async () => {
+        const {committee, nodesData, nodes, status, staking} = await whitelistedAndStakedNodes();
+        await committee.setCommitteeSize(5); // to save resources
+        await sendHeartbeat(status, nodesData.slice(0, 10)); // to save time
+        await committee.select();
+        for(const node of nodesData) {
+            const nodeBlocked = await committee.isNodeInCurrentOrNextCommittee(node.id);
+            if (nodeBlocked) {
+                await expect(nodes.connect(node.wallet).deleteNode(node.id))
+                .to.be.revertedWithCustomError(nodes, "NodeIsInCommittee");
+            }
+            else {
+                const amount = await staking.getStakedToNodeAmount(node.id);
+                if (amount > 0) {
+                    await expect(nodes.connect(node.wallet).deleteNode(node.id))
+                    .to.be.revertedWithCustomError(nodes, "NodeHasDelegations");
+                    await staking.retrieve(node.id, amount);
+                }
+                await nodes.connect(node.wallet).deleteNode(node.id);
+            }
+        }
+
+    });
 });

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -106,7 +106,7 @@ describe("Nodes", function () {
 
         await nodesContract.deleteNode(nodeId);
 
-        const response = await accessManagerContract.grantRole(await accessManagerContract.COMMITEE_ROLE(), deployer, 0n);
+        const response = await accessManagerContract.grantRole(await accessManagerContract.COMMITTEE_ROLE(), deployer, 0n);
         await response.wait();
 
         await expect(stakingContract.enable(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -81,6 +81,28 @@ describe("Staking", () => {
         expect(await staking.getNodeTotalStake(node)).to.be.eql(initialAmount - amount);
     });
 
+    it("should be possible to retrieve from deleted Node", async () => {
+        const {staking, nodesData, nodes} = await registeredOnlyNodes();
+        const [,user] = await ethers.getSigners();
+        const initialAmount = ethers.parseEther("3");
+        const amount = ethers.parseEther("1");
+        const node = nodesData[22]; // not in the current committee
+
+        await staking.connect(user).stake(node.id, {value: initialAmount});
+        (await staking.connect(user).getStakedAmount())
+            .should.be.equal(initialAmount);
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount);
+        await nodes.connect(node.wallet).deleteNode(node.id);
+        expect(await nodes.activeNodeExists(node.id)).to.be.eql(false);
+        expect(await staking.isNodeEnabled(node.id)).to.be.eql(false);
+        await staking.connect(user).retrieve(node.id, amount)
+            .should.changeEtherBalance(user, amount);
+        (await staking.connect(user).getStakedAmount())
+            .should.be.equal(initialAmount - amount);
+
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount - amount);
+    });
+
     it("should apply validator fee on rewards", async () => {
         const {staking, nodesData } = await registeredOnlyNodes();
         const [owner,user] = await ethers.getSigners();

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -265,7 +265,7 @@ describe("Staking", () => {
 
         // allow admin to disable nodes for testing
         const [admin,] = await ethers.getSigners();
-        const response = await accessManager.grantRole(await accessManager.COMMITEE_ROLE(), admin, 0n);
+        const response = await accessManager.grantRole(await accessManager.COMMITTEE_ROLE(), admin, 0n);
         await response.wait();
 
         const disabledNode = targetNodes.slice(-1)[0];

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1,4 +1,4 @@
-import chai, { assert } from "chai";
+import chai, { assert, expect } from "chai";
 import { registeredOnlyNodes, stakedNodes } from "./tools/fixtures";
 import { ethers } from "hardhat";
 import { zip } from "lodash";
@@ -16,6 +16,8 @@ describe("Staking", () => {
         await staking.connect(user).stake(node, {value: amount});
         (await staking.connect(user).getStakedAmount())
             .should.be.equal(amount);
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(amount);
+
     });
 
     it("should distribute rewards proportionally to stake", async () => {
@@ -27,7 +29,7 @@ describe("Staking", () => {
 
         await staking.connect(user1).stake(node, {value: amount1});
         await staking.connect(user2).stake(node, {value: amount2});
-
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(amount1 + amount2);
         // Pay reward
         await owner.sendTransaction({to: staking, value: reward});
 
@@ -35,6 +37,8 @@ describe("Staking", () => {
             .should.be.equal(amount1 + reward * amount1 / (amount1 + amount2));
         (await staking.connect(user2).getStakedAmount())
             .should.be.equal(amount2 + reward * amount2 / (amount1 + amount2));
+
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(amount1 + amount2 + reward);
     });
 
     it("should be able to stake to multiple nodes", async () => {
@@ -67,10 +71,14 @@ describe("Staking", () => {
         await staking.connect(user).stake(node, {value: initialAmount});
         (await staking.connect(user).getStakedAmount())
             .should.be.equal(initialAmount);
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(initialAmount);
+
         await staking.connect(user).retrieve(node, amount)
             .should.changeEtherBalance(user, amount);
         (await staking.connect(user).getStakedAmount())
             .should.be.equal(initialAmount - amount);
+
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(initialAmount - amount);
     });
 
     it("should apply validator fee on rewards", async () => {
@@ -92,8 +100,13 @@ describe("Staking", () => {
 
         await staking.connect(nodeWallet).claimAllFee(nodeWallet)
             .should.changeEtherBalance(nodeWallet, reward / 2n);
+
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(amount + reward / 2n);
+
         await staking.connect(user).retrieve(node, amount + reward / 2n)
             .should.changeEtherBalance(user, amount + reward / 2n);
+
+        expect(await staking.getNodeTotalStake(node)).to.be.eql(0n);
 
         (await staking.getEarnedFeeAmount(node))
             .should.be.equal(0n);
@@ -230,7 +243,7 @@ describe("Staking", () => {
     });
 
     it("should not pay rewards to stakers of unhealthy nodes", async () => {
-        const {staking, nodesData } = await registeredOnlyNodes();
+        const {staking, nodesData, accessManager } = await registeredOnlyNodes();
         const [owner, ...allUsers] = await ethers.getSigners();
         const amounts = [2, 3, 5].map(String).map(ethers.parseEther);
         const users = allUsers.slice(0, amounts.length);
@@ -247,7 +260,13 @@ describe("Staking", () => {
         for (const [user, node, amount] of zip(users, targetNodes, amounts)) {
             assert(node);
             await staking.connect(user).stake(node.id, {value: amount});
+            expect(await staking.getNodeTotalStake(node.id)).to.be.eql(amount);
         }
+
+        // allow admin to disable nodes for testing
+        const [admin,] = await ethers.getSigners();
+        const response = await accessManager.grantRole(await accessManager.COMMITEE_ROLE(), admin, 0n);
+        await response.wait();
 
         const disabledNode = targetNodes.slice(-1)[0];
         const delegatorOfDisabledNode = users.slice(-1)[0];

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -92,6 +92,7 @@ const deployFixture = async () => {
         node.id = await contracts.Nodes.getNodeId(node.wallet.address);
     };
     return {
+        accessManager: contracts.FairAccessManager,
         committee: contracts.Committee,
         dkg: contracts.DKG,
         nodes: contracts.Nodes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.10":
-  version: 0.1.0-remove-node.10
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.10"
-  checksum: 10c0/febcfb47b2f53dcb8455a3c2eb58c15de005c6fbe3ddc53487a721294a96e222087680fea0f604793e88fe44ac5912b8c5a07f953517a10069ad3caaa0f02ad2
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.11":
+  version: 0.1.0-remove-node.11
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.11"
+  checksum: 10c0/1bcbb9d419acfc96f244557f6b1077e0411dafacffdaf5c7f3e85aa42a28b6908f2113982a582aa8ff569eb68c1b3d4717798dd6f412e326ed1aa1613af24ee7
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.10"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.11"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.79":
-  version: 0.1.0-develop.79
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.79"
-  checksum: 10c0/aba1b3343900637b13e9aec5e14b1a56c43153f8f338636f5414d0b16b51f338cabb79e8e7e65f02841a24701ab415d50756002232dc486f663871ae1adeb2d3
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.7":
+  version: 0.1.0-remove-node.7
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.7"
+  checksum: 10c0/c6ef4c46fff1dbfac741780c25592a4c9ff70da9340bfcc467bb346e29874991736fe4545ba415998d717ea8f2b604997196be939753900c72883862b9ff3090
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.79"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.7"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.7":
-  version: 0.1.0-remove-node.7
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.7"
-  checksum: 10c0/c6ef4c46fff1dbfac741780c25592a4c9ff70da9340bfcc467bb346e29874991736fe4545ba415998d717ea8f2b604997196be939753900c72883862b9ff3090
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.9":
+  version: 0.1.0-remove-node.9
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.9"
+  checksum: 10c0/952d1bb92fe30fa305cd730c6c263e1812c881a592bbae0c95b51100275dfc7bdec0b6d2186ca9022d0c2883975cddde4a3c6b8071d4d7f5740fa4671a12bfee
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.7"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.9"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.11":
-  version: 0.1.0-remove-node.11
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.11"
-  checksum: 10c0/1bcbb9d419acfc96f244557f6b1077e0411dafacffdaf5c7f3e85aa42a28b6908f2113982a582aa8ff569eb68c1b3d4717798dd6f412e326ed1aa1613af24ee7
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.80":
+  version: 0.1.0-develop.80
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.80"
+  checksum: 10c0/50dc3fb9dc883f5383b8fff0ebf8ae77d1db50554dfcb56a95cd83043feedf5525efd88368fc99a409821a731d4c7f7978b736549cb303df5f44a6a8c569c6be
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.11"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.80"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.9":
-  version: 0.1.0-remove-node.9
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.9"
-  checksum: 10c0/952d1bb92fe30fa305cd730c6c263e1812c881a592bbae0c95b51100275dfc7bdec0b6d2186ca9022d0c2883975cddde4a3c6b8071d4d7f5740fa4671a12bfee
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.10":
+  version: 0.1.0-remove-node.10
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-remove-node.10"
+  checksum: 10c0/febcfb47b2f53dcb8455a3c2eb58c15de005c6fbe3ddc53487a721294a96e222087680fea0f604793e88fe44ac5912b8c5a07f953517a10069ad3caaa0f02ad2
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.9"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-remove-node.10"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"


### PR DESCRIPTION
Notes:
 - only node owners can delete a node using deleteNode().
 - foundation (smart-contracts default Admin) can delete any node by using deleteNodeByFoundation().
 - Added registration of domain names when initializing Nodes contract.
 - sets permissions to Staking.enable and Staking.disable functions to require COMMITTEE_ROLE.
 - Updated stake() and retrieve() to update totalDisabled Fair amount when staking/retrieving to/from disabled nodes

Fixes #83 