### PR TITLE
Remove restriction to unstake from the committee node

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -64,7 +64,6 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     error OnlyFeeReductionIsAllowed(uint16 currentRate, uint16 newRate);
     error ZeroAmount();
     error ZeroStakeToNode(NodeId node);
-    error NodeInCommittee(NodeId node);
     error NodeIsAlreadyDisabled(NodeId node);
     error NodeIsNotDisabled(NodeId node);
 
@@ -114,7 +113,6 @@ contract Staking is AccessManagedUpgradeable, IStaking {
     function retrieve(NodeId node, Fair value) external override {
         require(value > FundLibrary.ZERO_FAIR, ZeroAmount());
         require(_stakedNodes[msg.sender].contains(node), ZeroStakeToNode(node));
-        require(!committee.isNodeInCurrentOrNextCommittee(node), NodeInCommittee(node));
 
         bool nodeIsEnabled = isNodeEnabled(node);
         if (nodeIsEnabled) {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1,5 +1,5 @@
 import chai, { assert, expect } from "chai";
-import { registeredOnlyNodes } from "./tools/fixtures";
+import { registeredOnlyNodes, stakedNodes } from "./tools/fixtures";
 import { ethers } from "hardhat";
 import { zip } from "lodash";
 
@@ -250,6 +250,25 @@ describe("Staking", () => {
             .should.be.equal(0n);
         (await staking.getStakedAmountFor(user))
             .should.be.equal(amount2 + node2Reward + roundingError);
+    });
+
+    it("should allow to retrieve from a node from committee", async () => {
+        const {committee, staking} = await stakedNodes();
+        const [, user] = await ethers.getSigners();
+        const activeCommittee = await committee.getCommittee(await committee.getActiveCommitteeIndex());
+        const amount = ethers.parseEther("1");
+        const retrieveAmount = ethers.parseEther("0.5");
+
+        // stake to a committee node
+        const committeeNode = activeCommittee.nodes[0];
+        await staking.connect(user).stake(committeeNode, {value: amount});
+
+        // should allow retrieval from committee node
+        await staking.connect(user).retrieve(committeeNode, retrieveAmount)
+            .should.changeEtherBalance(user, retrieveAmount);
+
+        (await staking.connect(user).getStakedAmount())
+            .should.be.equal(amount - retrieveAmount);
     });
 
     it("should not pay rewards to stakers of unhealthy nodes", async () => {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -252,18 +252,6 @@ describe("Staking", () => {
             .should.be.equal(amount2 + node2Reward + roundingError);
     });
 
-    it("should not allow to retrieve from a node from committee", async () => {
-        const {committee, staking} = await stakedNodes();
-        const activeCommittee = await committee.getCommittee(await committee.getActiveCommitteeIndex());
-        for (const node of activeCommittee.nodes) {
-            await staking.retrieve(node, 1)
-                .should.be.revertedWithCustomError(
-                    staking,
-                    "NodeInCommittee"
-                ).withArgs(node);
-        }
-    });
-
     it("should not pay rewards to stakers of unhealthy nodes", async () => {
         const {staking, nodesData, accessManager } = await registeredOnlyNodes();
         const [owner, ...allUsers] = await ethers.getSigners();

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1,5 +1,5 @@
 import chai, { assert, expect } from "chai";
-import { registeredOnlyNodes, stakedNodes } from "./tools/fixtures";
+import { registeredOnlyNodes } from "./tools/fixtures";
 import { ethers } from "hardhat";
 import { zip } from "lodash";
 


### PR DESCRIPTION
Removed the restriction and allow to unstake from all nodes.
Closes #77 