### PR TITLE
Disable select() function during committee rotation after successful DKG

### DIFF
--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -397,6 +397,11 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         return Precompiled.getRandomNumber(skaleRng);
     }
 
+    function _isCommitteeRotationInProgress() private view returns (bool inProgress) {
+        Committee storage latestCommittee = _getCommittee(lastCommitteeIndex);
+        return Timestamp.unwrap(latestCommittee.startingTimestamp) == type(uint256).max;
+    }
+
     function _next(CommitteeIndex index) private pure returns (CommitteeIndex nextIndex) {
         return CommitteeIndex.wrap(CommitteeIndex.unwrap(index) + 1);
     }
@@ -410,8 +415,4 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         return share;
     }
 
-    function _isCommitteeRotationInProgress() private view returns (bool inProgress) {
-        Committee storage latestCommittee = _getCommittee(lastCommitteeIndex);
-        return Timestamp.unwrap(latestCommittee.startingTimestamp) == type(uint256).max;
-    }
 }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -111,6 +111,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     }
 
     function select() external override restricted {
+        require(
+            _canSelectNewCommittee(),
+            CommitteeRotationInProgress()
+        );
         _flushReceivedRewards();
         IRandom.RandomGenerator memory generator = Random.create(_safeGetRandom());
         NodeId[] memory members = _pool.sample(committeeSize, generator);

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -174,10 +174,6 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
             Duration.unwrap(delay) + 1 > Duration.unwrap(minTransitionDelay),
             TransitionDelayTooShort()
         );
-        require(
-            !_isCommitteeRotationInProgress(),
-            CommitteeRotationInProgress()
-        );
         emit TransitionDelayUpdated(transitionDelay, delay);
         transitionDelay = delay;
     }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -84,6 +84,7 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     error InvalidSkaleRngContract(address rng);
     error NodeNotActive(NodeId node);
     error TransitionDelayTooShort();
+    error CommitteeRotationInProgress();
 
     modifier onlyDkg() {
         require(msg.sender == address(dkg), SenderIsNotDkg(msg.sender));
@@ -172,6 +173,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         require(
             Duration.unwrap(delay) + 1 > Duration.unwrap(minTransitionDelay),
             TransitionDelayTooShort()
+        );
+        require(
+            !_isCommitteeRotationInProgress(),
+            CommitteeRotationInProgress()
         );
         emit TransitionDelayUpdated(transitionDelay, delay);
         transitionDelay = delay;
@@ -403,5 +408,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
     function _shareToWeight(uint256 share) private pure returns (uint256 weight)
     {
         return share;
+    }
+
+    function _isCommitteeRotationInProgress() private view returns (bool inProgress) {
+        Committee storage latestCommittee = _getCommittee(lastCommitteeIndex);
+        return Timestamp.unwrap(latestCommittee.startingTimestamp) == type(uint256).max;
     }
 }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -393,9 +393,10 @@ contract Committee is AccessManagedUpgradeable, ICommittee {
         return Precompiled.getRandomNumber(skaleRng);
     }
 
-    function _isCommitteeRotationInProgress() private view returns (bool inProgress) {
-        Committee storage latestCommittee = _getCommittee(lastCommitteeIndex);
-        return Timestamp.unwrap(latestCommittee.startingTimestamp) == type(uint256).max;
+    function _canSelectNewCommittee() private view returns (bool canSelect) {
+        Committee memory latestCommittee = _getCommittee(lastCommitteeIndex);
+        return Timestamp.unwrap(latestCommittee.startingTimestamp) == type(uint256).max ||
+            latestCommittee.startingTimestamp < Timestamp.wrap(block.timestamp);
     }
 
     function _next(CommitteeIndex index) private pure returns (CommitteeIndex nextIndex) {

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -241,6 +241,31 @@ describe("Committee", () => {
         );
     });
 
+    it.only("should not allow to set transition delay during committee rotation", async () => {
+        const {committee, status, dkg, nodesData} = await whitelistedAndStakedNodes();
+        const subset = nodesData.slice(0, 5);
+        await sendHeartbeat(status, subset);
+
+        await committee.setCommitteeSize(2);
+
+        // Start a committee rotation by calling select()
+        await committee.select();
+
+        // Now try to change transition delay while rotation is in progress
+        const newTransitionDelay = 700n;
+        await expect(committee.setTransitionDelay(newTransitionDelay))
+            .to.be.revertedWithCustomError(committee, "CommitteeRotationInProgress");
+
+        // Complete the DKG process
+        const nextCommitteeIndex = await committee.getActiveCommitteeIndex() + 1n;
+        const nextCommittee = await committee.getCommittee(nextCommitteeIndex);
+        await runDkg(dkg, nodesData, nextCommittee.dkg);
+
+        // Now setting transition delay should work again
+        await committee.setTransitionDelay(newTransitionDelay);
+        (await committee.transitionDelay()).should.be.equal(newTransitionDelay);
+    });
+
     it("should check if a node in the committee or will be there soon", async () => {
         const {committee, dkg, nodesData, status} = await whitelistedAndStakedNodes();
         await committee.setCommitteeSize(5); // to save time

--- a/test/Committee.ts
+++ b/test/Committee.ts
@@ -241,7 +241,7 @@ describe("Committee", () => {
         );
     });
 
-    it.only("should not allow to set transition delay during committee rotation", async () => {
+    it("should not allow to select committee after successful DKG but before committee starts", async () => {
         const {committee, status, dkg, nodesData} = await whitelistedAndStakedNodes();
         const subset = nodesData.slice(0, 5);
         await sendHeartbeat(status, subset);
@@ -251,19 +251,28 @@ describe("Committee", () => {
         // Start a committee rotation by calling select()
         await committee.select();
 
-        // Now try to change transition delay while rotation is in progress
-        const newTransitionDelay = 700n;
-        await expect(committee.setTransitionDelay(newTransitionDelay))
-            .to.be.revertedWithCustomError(committee, "CommitteeRotationInProgress");
-
         // Complete the DKG process
         const nextCommitteeIndex = await committee.getActiveCommitteeIndex() + 1n;
         const nextCommittee = await committee.getCommittee(nextCommitteeIndex);
         await runDkg(dkg, nodesData, nextCommittee.dkg);
 
-        // Now setting transition delay should work again
-        await committee.setTransitionDelay(newTransitionDelay);
-        (await committee.transitionDelay()).should.be.equal(newTransitionDelay);
+        // Now try to select a new committee after DKG completed but before committee starts
+        // This should fail because off-chain components have already scheduled migration
+        await expect(committee.select())
+            .to.be.revertedWithCustomError(committee, "CommitteeRotationInProgress");
+
+        // Wait for the committee to start
+        await skipTime(await committee.transitionDelay());
+
+        // Ensure nodes are still healthy after the delay
+        await sendHeartbeat(status, subset);
+
+        // Now selecting a new committee should work again
+        await committee.select();
+        const anotherCommitteeIndex = nextCommitteeIndex + 1n;
+        const anotherCommittee = await committee.getCommittee(anotherCommitteeIndex);
+        anotherCommittee.dkg.should.not.be.equal(0n);
+        anotherCommittee.startingTimestamp.should.be.equal(2n ** 256n - 1n);
     });
 
     it("should check if a node in the committee or will be there soon", async () => {


### PR DESCRIPTION
Disable select() function during committee rotation after successful DKG
closes #107 