### PR TITLE
never delete public keys of active nodes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -31,7 +31,7 @@ All main smart contracts are [AccessManaged](https://github.com/OpenZeppelin/ope
 
 FAIR supports two types of nodes: Passive and Active Nodes.
 
-- **Active Nodes**: Actively contribute to the functioning and security of the network. The registered owner of an Active Node cannot own any other node (Active or Passive). Active nodes cannot change ownership.
+- **Active Nodes**: Actively contribute to the functioning and security of the network. The registered owner of an Active Node cannot own any other node (Active or Passive). Active nodes cannot change ownership. Public keys of active nodes will be used to verify blocks, thus these must be available forever, even after node deletion.
 - **Passive Nodes**: Do not actively contribute. The owner of a Passive Node can own multiple Passive Nodes. Passive Nodes can freely change ownership.
 
 ```solidity
@@ -48,7 +48,7 @@ struct Node {
 #### Invariants
 
 - Node IDs are unique.
-- Active Node owners cannot own any other Node.
+- Active Node owners cannot own any other Node, **even if the active node is deleted**.
 - Passive Node owners can own multiple Passive Nodes.
 - Registered node IPs must be unique.
 - Domain names can be empty, but if not empty, they must be unique.

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -97,7 +97,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     error DomainNameAlreadyTaken(string domainName);
     error NodeDoesNotExist(NodeId nodeId);
     error NodeWasDeleted(NodeId nodeId);
-    error NodeWasNeverRegistered(NodeId nodeId);
+    error ActiveNodeWasNeverRegistered(NodeId nodeId);
     error PortShouldNotBeZero();
     error SenderIsNotNodeOwner();
     error SenderIsNotNewNodeOwner();
@@ -374,7 +374,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
     function getPublicKeyForNodeId(NodeId nodeId) external view override returns (bytes32[2] memory publicKey) {
         publicKey = _nodesInfo[nodeId].publicKey;
-        require(publicKey[0] != bytes32(0) && publicKey[1] != bytes32(0), NodeWasNeverRegistered(nodeId));
+        require(publicKey[0] != bytes32(0) && publicKey[1] != bytes32(0), ActiveNodeWasNeverRegistered(nodeId));
     }
 
     function getActiveNodeIds() external view override returns (NodeId[] memory nodeIds) {

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -42,6 +42,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     using TypedMap for TypedMap.AddressToNodeIdMap;
     using TypedMap for TypedMap.AddressToNodeIdSetMap;
 
+    struct NodeInfo {
+        bytes32[2] publicKey;
+    }
+
     bytes4 public constant ZERO_IPV4 = bytes4(0);
     bytes16 public constant ZERO_IPV6 = bytes16(0);
 
@@ -53,7 +57,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
     ICommittee public committeeContract;
 
-    //Maps addresses to NodeIds
+    // Mapping from node ID to publicKey - only for active nodes, including deleted
+    mapping(NodeId nodeId => NodeInfo nodeInfo) private _nodesInfo;
+
+    //Maps addresses to NodeIds, includes deleted
     TypedMap.AddressToNodeIdMap private _activeNodesAddressToId;
 
     //Maps addresses to NodeIds
@@ -77,7 +84,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     TypedSet.NodeIdSet private _activeNodeIds;
 
     error NodeIsInCommittee(NodeId nodeId);
-    error AddressIsAlreadyAssignedToNode(address nodeAddress);
+    error AddressWasAlreadyAssignedToNode(address nodeAddress);
     error AddressIsNotAssignedToAnyNode(address nodeAddress);
     error PassiveNodeAlreadyExistsForAddress(address nodeAddress, NodeId nodeId);
     error AddressInUseByPassiveNodes(address nodeAddress);
@@ -89,6 +96,8 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     error IpIsNotAvailable(bytes ip);
     error DomainNameAlreadyTaken(string domainName);
     error NodeDoesNotExist(NodeId nodeId);
+    error NodeWasDeleted(NodeId nodeId);
+    error NodeWasNeverRegistered(NodeId nodeId);
     error PortShouldNotBeZero();
     error SenderIsNotNodeOwner();
     error SenderIsNotNewNodeOwner();
@@ -137,9 +146,17 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         _;
     }
 
-    function initialize(address initialAuthority, Node[] calldata initialNodes) public override initializer {
+    function initialize(
+        address initialAuthority,
+        Node[] calldata initialNodes,
+        bytes32[2][] calldata nodesPublicKeys
+    )
+        public
+        override
+        initializer
+    {
         __AccessManaged_init(initialAuthority);
-        _initializeGroup(initialNodes);
+        _initializeGroup(initialNodes, nodesPublicKeys);
     }
 
     function setCommittee(ICommittee committeeAddress) external override restricted {
@@ -203,9 +220,9 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         require(_isPassiveNode(nodeId), ActiveNodesCannotChangeOwnership());
         require(
             !_isAddressOfActiveNode(newOwner),
-            AddressIsAlreadyAssignedToNode(newOwner)
+            AddressWasAlreadyAssignedToNode(newOwner)
         );
-
+        emit NodeOwnerChangeRequested(nodeId, msg.sender, newOwner);
         ownerChangeRequests[nodeId] = newOwner;
     }
 
@@ -260,7 +277,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
         nodes[nodeId] = Node({
             id: nodeId,
-            publicKey: [bytes32(0),bytes32(0)],
             port: port,
             nodeAddress: msg.sender,
             ip: ip,
@@ -331,6 +347,10 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             AddressIsNotAssignedToAnyNode(nodeAddress)
         );
         nodeId = _activeNodesAddressToId.get(nodeAddress);
+
+        // Address may have been assigned to an active node in the past, but the node may have been deleted
+        // We do not allow active nodes with duplicate addresses, even if the old was deleted
+        require(_isActiveNode(nodeId), NodeWasDeleted(nodeId));
     }
 
     function getPassiveNodeIdsForAddress(
@@ -350,6 +370,11 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
     function getPassiveNodeIds() external view override returns (NodeId[] memory nodeIds) {
         nodeIds = _passiveNodeIds.values();
+    }
+
+    function getPublicKeyForNodeId(NodeId nodeId) external view override returns (bytes32[2] memory publicKey) {
+        publicKey = _nodesInfo[nodeId].publicKey;
+        require(publicKey[0] != bytes32(0) && publicKey[1] != bytes32(0), NodeWasNeverRegistered(nodeId));
     }
 
     function getActiveNodeIds() external view override returns (NodeId[] memory nodeIds) {
@@ -387,11 +412,14 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
         nodes[nodeId] = Node({
             id: nodeId,
-            publicKey: publicKey,
             port: port,
             nodeAddress: nodeAddress,
             ip: ip,
             domainName: domainName
+        });
+
+        _nodesInfo[nodeId] = NodeInfo({
+            publicKey: publicKey
         });
 
         emit NodeRegistered(nodeId, nodeAddress, ip, port);
@@ -409,7 +437,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         if (_isActiveNode(id)) {
             IStatus statusContract = IStatus(committeeContract.status());
             assert(_activeNodeIds.remove(id));
-            assert(_activeNodesAddressToId.remove(nodeOwner));
             emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
             statusContract.nodeRemoved(id);
             committeeContract.nodeRemoved(id);
@@ -438,14 +465,14 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         );
         require(
             _activeNodesAddressToId.set(nodeAddress, nodeId),
-            AddressIsAlreadyAssignedToNode(nodeAddress)
+            AddressWasAlreadyAssignedToNode(nodeAddress)
         );
     }
 
     function _setPassiveNodeIdForAddress(address nodeAddress, NodeId nodeId) private {
         require(
             !_isAddressOfActiveNode(nodeAddress),
-            AddressIsAlreadyAssignedToNode(nodeAddress)
+            AddressWasAlreadyAssignedToNode(nodeAddress)
         );
 
         require(
@@ -458,7 +485,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         }
     }
 
-    function _initializeGroup(Node[] calldata initialNodes) private {
+    function _initializeGroup(Node[] calldata initialNodes, bytes32[2][] calldata publicKeys) private {
         uint256 length = initialNodes.length;
         for (uint256 i; i < length; ++i) {
             Node calldata initNode = initialNodes[i];
@@ -468,7 +495,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
                 ip: initNode.ip,
                 port: initNode.port,
                 domainName: initNode.domainName,
-                publicKey: initNode.publicKey
+                publicKey: publicKeys[i]
             });
         }
     }

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -372,7 +372,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         nodeIds = _passiveNodeIds.values();
     }
 
-    function getPublicKeyForNodeId(NodeId nodeId) external view override returns (bytes32[2] memory publicKey) {
+    function getPublicKey(NodeId nodeId) external view override returns (bytes32[2] memory publicKey) {
         publicKey = _nodesInfo[nodeId].publicKey;
         require(publicKey[0] != bytes32(0) && publicKey[1] != bytes32(0), ActiveNodeWasNeverRegistered(nodeId));
     }

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -82,7 +82,6 @@ async function fetchNodes() {
         throw new Error("Node IDs cannot contain 0");
     }
     const nodeList: NodeStruct[] = [];
-    const publicKeys: [BytesLike, BytesLike][] = []
     for (const nodeId of nodeIds) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
             nodes.getNodeIP(nodeId),
@@ -91,7 +90,6 @@ async function fetchNodes() {
             nodes.getNodePort(nodeId),
             nodes.getNodePublicKey(nodeId)
         ]);
-        publicKeys.push(publicKey);
         nodeList.push({
             id: nodeId,
             ip,

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -17,7 +17,7 @@ import {
     Status,
     RewardWallet
 } from "../typechain-types";
-import { AddressLike, BigNumberish, BytesLike, toNumber } from "ethers";
+import { AddressLike, BigNumberish, BytesLike } from "ethers";
 import { skaleContracts } from "@skalenetwork/skale-contracts-ethers-v6";
 import {
     IKeyStorage,
@@ -36,6 +36,10 @@ export const contracts = [
     "Status",
     "Staking"
 ];
+
+export interface NodeStruct extends INodes.NodeStruct {
+    publicKey: [BytesLike, BytesLike];
+}
 
 export interface DeployedContracts {
     Committee: Committee,
@@ -77,7 +81,7 @@ async function fetchNodes() {
     if (nodeIds.includes(0n)) {
         throw new Error("Node IDs cannot contain 0");
     }
-    const nodeList: INodes.NodeStruct[] = [];
+    const nodeList: NodeStruct[] = [];
     const publicKeys: [BytesLike, BytesLike][] = []
     for (const nodeId of nodeIds) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
@@ -94,9 +98,10 @@ async function fetchNodes() {
             domainName,
             nodeAddress,
             port,
+            publicKey
         });
     }
-    return {nodeList, publicKeys};
+    return nodeList;
 }
 
 async function fetchDkgCommonPublicKey() {
@@ -111,24 +116,18 @@ async function fetchDkgCommonPublicKey() {
     return commonPublicKey;
 }
 
-export const deploy = async (nodeList?: INodes.NodeStruct[], publicKeys?: [BytesLike, BytesLike][], commonPublicKey?: IDkg.G2PointStruct): Promise<DeployedContracts> => {
+export const deploy = async (nodeList?: NodeStruct[], commonPublicKey?: IDkg.G2PointStruct): Promise<DeployedContracts> => {
     const [deployer] = await ethers.getSigners();
     const deployedContracts: DeployedContracts = {} as DeployedContracts;
-    if (!nodeList || !publicKeys) {
-        ({nodeList, publicKeys} = await fetchNodes());
+    if (!nodeList) {
+        nodeList = await fetchNodes();
     }
     commonPublicKey = commonPublicKey || await fetchDkgCommonPublicKey();
 
     deployedContracts.FairAccessManager = await deployFairAccessManager(deployer);
-    publicKeys = publicKeys
-        .map((val, idx) => ({ val, key: toNumber(nodeList[idx].id)}))
-        .sort((a, b) => a.key - b.key)
-        .map(item => item.val);
-
     deployedContracts.Nodes = await deployNodes(
         deployedContracts.FairAccessManager,
-        [...nodeList].sort((a, b) => Number(a.id) - Number(b.id)),
-        publicKeys
+        [...nodeList].sort((a, b) => Number(a.id) - Number(b.id))
     );
     deployedContracts.Committee = await deployCommittee(
         deployedContracts.FairAccessManager,
@@ -207,13 +206,13 @@ const deployCommittee = async (
     ) as Committee;
 }
 
-const deployNodes = async (accessManager: FairAccessManager, nodeList: INodes.NodeStruct[], publicKeys: [BytesLike, BytesLike][]): Promise<Nodes> => {
+const deployNodes = async (accessManager: FairAccessManager, nodeList: NodeStruct[]): Promise<Nodes> => {
     return await deployContract(
         "Nodes",
         [
             await ethers.resolveAddress(accessManager),
             nodeList,
-            publicKeys
+            nodeList.map(node => node.publicKey)
         ]
     ) as Nodes;
 }

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -17,7 +17,7 @@ import {
     Status,
     RewardWallet
 } from "../typechain-types";
-import { AddressLike, BigNumberish } from "ethers";
+import { AddressLike, BigNumberish, BytesLike, toNumber } from "ethers";
 import { skaleContracts } from "@skalenetwork/skale-contracts-ethers-v6";
 import {
     IKeyStorage,
@@ -78,6 +78,7 @@ async function fetchNodes() {
         throw new Error("Node IDs cannot contain 0");
     }
     const nodeList: INodes.NodeStruct[] = [];
+    const publicKeys: [BytesLike, BytesLike][] = []
     for (const nodeId of nodeIds) {
         const [ip, domainName ,nodeAddress, port, publicKey] = await Promise.all([
             nodes.getNodeIP(nodeId),
@@ -86,16 +87,16 @@ async function fetchNodes() {
             nodes.getNodePort(nodeId),
             nodes.getNodePublicKey(nodeId)
         ]);
+        publicKeys.push(publicKey);
         nodeList.push({
             id: nodeId,
             ip,
             domainName,
             nodeAddress,
             port,
-            publicKey
         });
     }
-    return nodeList;
+    return {nodeList, publicKeys};
 }
 
 async function fetchDkgCommonPublicKey() {
@@ -110,16 +111,24 @@ async function fetchDkgCommonPublicKey() {
     return commonPublicKey;
 }
 
-export const deploy = async (nodeList?: INodes.NodeStruct[], commonPublicKey?: IDkg.G2PointStruct): Promise<DeployedContracts> => {
+export const deploy = async (nodeList?: INodes.NodeStruct[], publicKeys?: [BytesLike, BytesLike][], commonPublicKey?: IDkg.G2PointStruct): Promise<DeployedContracts> => {
     const [deployer] = await ethers.getSigners();
     const deployedContracts: DeployedContracts = {} as DeployedContracts;
-    nodeList = nodeList || await fetchNodes();
+    if (!nodeList || !publicKeys) {
+        ({nodeList, publicKeys} = await fetchNodes());
+    }
     commonPublicKey = commonPublicKey || await fetchDkgCommonPublicKey();
 
     deployedContracts.FairAccessManager = await deployFairAccessManager(deployer);
+    publicKeys = publicKeys
+        .map((val, idx) => ({ val, key: toNumber(nodeList[idx].id)}))
+        .sort((a, b) => a.key - b.key)
+        .map(item => item.val);
+
     deployedContracts.Nodes = await deployNodes(
         deployedContracts.FairAccessManager,
-        [...nodeList].sort((a, b) => Number(a.id) - Number(b.id))
+        [...nodeList].sort((a, b) => Number(a.id) - Number(b.id)),
+        publicKeys
     );
     deployedContracts.Committee = await deployCommittee(
         deployedContracts.FairAccessManager,
@@ -198,12 +207,13 @@ const deployCommittee = async (
     ) as Committee;
 }
 
-const deployNodes = async (accessManager: FairAccessManager, nodeList: INodes.NodeStruct[]): Promise<Nodes> => {
+const deployNodes = async (accessManager: FairAccessManager, nodeList: INodes.NodeStruct[], publicKeys: [BytesLike, BytesLike][]): Promise<Nodes> => {
     return await deployContract(
         "Nodes",
         [
             await ethers.resolveAddress(accessManager),
-            nodeList
+            nodeList,
+            publicKeys
         ]
     ) as Nodes;
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.85",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-keep-public-keys.2",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-keep-public-keys.3",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.86",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-keep-public-keys.2",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-keep-public-keys.3",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -482,6 +482,8 @@ describe("Nodes", function () {
 
         await expect(nodesContract.connect(user1).requestChangeOwner(passiveNode, deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
+
+        await expect(nodesContract.getPublicKeyForNodeId(passiveNode + 1n)).to.be.revertedWithCustomError(nodesContract, "ActiveNodeWasNeverRegistered");
     });
 
     it("should should not allow changing nodes data if node in current or next committee", async function () {

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -67,7 +67,7 @@ describe("Nodes", function () {
         expect(node.port).to.equal(8000n);
         expect(Buffer.from(getBytes(node.ip))).to.eql(MOCK_IP_0_BYTES);
         expect(node.nodeAddress).to.equal(deployer.address);
-        expect(await nodesContract.getPublicKeyForNodeId(nodeId)).to.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKey(nodeId)).to.eql(deployerPubKey);
 
         expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
 
@@ -86,7 +86,7 @@ describe("Nodes", function () {
         expect(node.port).to.equal(8000n);
         expect(Buffer.from(getBytes(node.ip))).to.eql(MOCK_IP_0_BYTES);
         expect(node.nodeAddress).to.equal(deployer.address);
-        expect(await nodesContract.getPublicKeyForNodeId(nodeId)).to.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKey(nodeId)).to.eql(deployerPubKey);
 
         expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
         expect(await nodesContract.getActiveNodeIds()).to.include(nodeId);
@@ -466,7 +466,7 @@ describe("Nodes", function () {
         const node = await nodesContract.getNodeId(deployer.address);
         await nodesContract.deleteNode(node);
         await expect(nodesContract.getNodeId(deployer.address)).to.be.revertedWithCustomError(nodesContract, "NodeWasDeleted");
-        expect(await nodesContract.getPublicKeyForNodeId(node)).to.be.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKey(node)).to.be.eql(deployerPubKey);
 
         await expect(nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000))
         .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
@@ -474,7 +474,7 @@ describe("Nodes", function () {
         await expect(nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000))
         .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
 
-        expect(await nodesContract.getPublicKeyForNodeId(node)).to.be.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKey(node)).to.be.eql(deployerPubKey);
 
         await nodesContract.connect(user1).registerPassiveNode(MOCK_IP_1_BYTES, 8000);
 
@@ -483,7 +483,7 @@ describe("Nodes", function () {
         await expect(nodesContract.connect(user1).requestChangeOwner(passiveNode, deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
 
-        await expect(nodesContract.getPublicKeyForNodeId(passiveNode + 1n)).to.be.revertedWithCustomError(nodesContract, "ActiveNodeWasNeverRegistered");
+        await expect(nodesContract.getPublicKey(passiveNode + 1n)).to.be.revertedWithCustomError(nodesContract, "ActiveNodeWasNeverRegistered");
     });
 
     it("should should not allow changing nodes data if node in current or next committee", async function () {

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -67,7 +67,7 @@ describe("Nodes", function () {
         expect(node.port).to.equal(8000n);
         expect(Buffer.from(getBytes(node.ip))).to.eql(MOCK_IP_0_BYTES);
         expect(node.nodeAddress).to.equal(deployer.address);
-        expect(node.publicKey).to.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKeyForNodeId(nodeId)).to.eql(deployerPubKey);
 
         expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
 
@@ -86,7 +86,7 @@ describe("Nodes", function () {
         expect(node.port).to.equal(8000n);
         expect(Buffer.from(getBytes(node.ip))).to.eql(MOCK_IP_0_BYTES);
         expect(node.nodeAddress).to.equal(deployer.address);
-        expect(node.publicKey).to.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKeyForNodeId(nodeId)).to.eql(deployerPubKey);
 
         expect(await nodesContract.getNodeId(deployer.address)).to.equal(nodeId);
         expect(await nodesContract.getActiveNodeIds()).to.include(nodeId);
@@ -125,11 +125,11 @@ describe("Nodes", function () {
         expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeId);
         expect(await nodesContract.activeNodeExists(nodeId)).to.eql(false);
 
-        await nodesContract.connect(user1).registerNode(MOCK_IP_0_BYTES, user1PubKey, 8000);
-        const nodeIdV2 = await nodesContract.getNodeId(user1.address) as BigNumberish;
-        await nodesContract.connect(user1).setDomainName(nodeIdV2, MOCK_DOMAIN_NAME_0);
+        await nodesContract.connect(user2).registerNode(MOCK_IP_0_BYTES, user2PubKey, 8000);
+        const nodeIdV2 = await nodesContract.getNodeId(user2.address) as BigNumberish;
+        await nodesContract.connect(user2).setDomainName(nodeIdV2, MOCK_DOMAIN_NAME_0);
 
-        await expect(nodesContract.connect(user1).deleteNodeByFoundation(nodeIdV2)).to.be.reverted;
+        await expect(nodesContract.connect(user2).deleteNodeByFoundation(nodeIdV2)).to.be.reverted;
         await nodesContract.connect(deployer).deleteNodeByFoundation(nodeIdV2);
 
         await expect(nodesContract.getNode(nodeIdV2)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
@@ -229,9 +229,9 @@ describe("Nodes", function () {
 
         // Node address is taken by active node
         await expect(nodesContract.registerPassiveNode(MOCK_IP_1_BYTES, 8000))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsAlreadyAssignedToNode");
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
         await expect(nodesContract.registerNode(MOCK_IP_1_BYTES, deployerPubKey, 8000))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsAlreadyAssignedToNode");
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
 
         // IP address is taken by active node
         await expect(nodesContract.connect(user1).registerPassiveNode(MOCK_IP_0_BYTES, 8000))
@@ -351,7 +351,7 @@ describe("Nodes", function () {
         await nodesContract.connect(user1).registerNode(MOCK_IP_1_BYTES, user1PubKey, 8000);
 
         await expect(nodesContract.requestChangeOwner(firstNodeId, user1.address))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsAlreadyAssignedToNode");
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
     });
 
     it("should allow only new Node owner to submit Node address change", async () => {
@@ -399,7 +399,7 @@ describe("Nodes", function () {
         await nodesContract.connect(user1).registerNode(MOCK_IP_1_BYTES, user1PubKey, 8000);
 
         await expect(nodesContract.connect(user1).confirmOwnerChange(nodeId))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsAlreadyAssignedToNode");
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
 
         const node = await nodesContract.getNode(nodeId);
         expect(node.nodeAddress).to.equal(deployer.address);
@@ -459,6 +459,29 @@ describe("Nodes", function () {
 
         await expect(nodesContract.confirmOwnerChange(firstNodeId))
         .to.be.revertedWithCustomError(nodesContract, "PassiveNodeAlreadyExistsForAddress");
+    });
+
+    it("should never allow duplicate public keys from active nodes even after deletion", async function () {
+        await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000);
+        const node = await nodesContract.getNodeId(deployer.address);
+        await nodesContract.deleteNode(node);
+        await expect(nodesContract.getNodeId(deployer.address)).to.be.revertedWithCustomError(nodesContract, "NodeWasDeleted");
+        expect(await nodesContract.getPublicKeyForNodeId(node)).to.be.eql(deployerPubKey);
+
+        await expect(nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000))
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
+
+        await expect(nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000))
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
+
+        expect(await nodesContract.getPublicKeyForNodeId(node)).to.be.eql(deployerPubKey);
+
+        await nodesContract.connect(user1).registerPassiveNode(MOCK_IP_1_BYTES, 8000);
+
+        const [passiveNode] = await nodesContract.getPassiveNodeIdsForAddress(user1.address);
+
+        await expect(nodesContract.connect(user1).requestChangeOwner(passiveNode, deployer.address))
+        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
     });
 
     it("should should not allow changing nodes data if node in current or next committee", async function () {

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -3,10 +3,10 @@
 import {
     loadFixture
 } from "@nomicfoundation/hardhat-network-helpers";
-import { deploy } from "../../migrations/deploy";
-import { HDNodeWallet, BytesLike, Wallet } from "ethers";
+import { deploy, NodeStruct } from "../../migrations/deploy";
+import { HDNodeWallet, Wallet } from "ethers";
 import { ethers } from "hardhat";
-import { INodes, IDkg, Nodes, Status, Staking } from "../../typechain-types";
+import { IDkg, Nodes, Status, Staking } from "../../typechain-types";
 import { getPublicKey } from "./signatures";
 
 // Parameters
@@ -28,9 +28,8 @@ export const commonPublicKey: IDkg.G2PointStruct = {
 
 // Auxiliary functions
 
-export interface NodeData extends INodes.NodeStruct {
+export interface NodeData extends NodeStruct {
     wallet: HDNodeWallet;
-    publicKey: [BytesLike, BytesLike];
 }
 
 const getIp = (): Uint8Array => ethers.randomBytes(4);
@@ -56,7 +55,7 @@ const generateRandomNodes = async (initialNumberOfNodes?: number) => {
         });
 
     }
-    return {nodesData, publicKeys: nodesData.map(node => node.publicKey)};
+    return nodesData;
 }
 
 const registerNodes = async (nodes: Nodes, nodesData: NodeData[]) => {
@@ -88,8 +87,8 @@ const stake = async (staking: Staking, nodesData: NodeData[]) => {
 // Fixtures
 
 const deployFixture = async () => {
-    const {nodesData, publicKeys} = await generateRandomNodes(initialNumberOfNodes);
-    const contracts = await deploy(nodesData, publicKeys, commonPublicKey);
+    const nodesData = await generateRandomNodes(initialNumberOfNodes);
+    const contracts = await deploy(nodesData, commonPublicKey);
     for (const node of nodesData) {
         node.id = await contracts.Nodes.getNodeId(node.wallet.address);
     };
@@ -109,7 +108,7 @@ const deployFixture = async () => {
 const registeredOnlyNodesFixture = async () => {
     const contracts = await cleanDeployment();
     const { nodes } = contracts;
-    const {nodesData} = await generateRandomNodes(numberOfNodes - initialNumberOfNodes);
+    const nodesData = await generateRandomNodes(numberOfNodes - initialNumberOfNodes);
 
     await registerNodes(nodes, nodesData);
 

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -4,7 +4,7 @@ import {
     loadFixture
 } from "@nomicfoundation/hardhat-network-helpers";
 import { deploy } from "../../migrations/deploy";
-import { HDNodeWallet, Wallet } from "ethers";
+import { HDNodeWallet, BytesLike, Wallet } from "ethers";
 import { ethers } from "hardhat";
 import { INodes, IDkg, Nodes, Status, Staking } from "../../typechain-types";
 import { getPublicKey } from "./signatures";
@@ -30,6 +30,7 @@ export const commonPublicKey: IDkg.G2PointStruct = {
 
 export interface NodeData extends INodes.NodeStruct {
     wallet: HDNodeWallet;
+    publicKey: [BytesLike, BytesLike];
 }
 
 const getIp = (): Uint8Array => ethers.randomBytes(4);
@@ -53,8 +54,9 @@ const generateRandomNodes = async (initialNumberOfNodes?: number) => {
             wallet: wallet,
             publicKey: await getPublicKey(wallet)
         });
+
     }
-    return nodesData;
+    return {nodesData, publicKeys: nodesData.map(node => node.publicKey)};
 }
 
 const registerNodes = async (nodes: Nodes, nodesData: NodeData[]) => {
@@ -86,8 +88,8 @@ const stake = async (staking: Staking, nodesData: NodeData[]) => {
 // Fixtures
 
 const deployFixture = async () => {
-    const nodesData = await generateRandomNodes(initialNumberOfNodes);
-    const contracts = await deploy(nodesData, commonPublicKey);
+    const {nodesData, publicKeys} = await generateRandomNodes(initialNumberOfNodes);
+    const contracts = await deploy(nodesData, publicKeys, commonPublicKey);
     for (const node of nodesData) {
         node.id = await contracts.Nodes.getNodeId(node.wallet.address);
     };
@@ -107,7 +109,7 @@ const deployFixture = async () => {
 const registeredOnlyNodesFixture = async () => {
     const contracts = await cleanDeployment();
     const { nodes } = contracts;
-    const nodesData = await generateRandomNodes(numberOfNodes - initialNumberOfNodes);
+    const {nodesData} = await generateRandomNodes(numberOfNodes - initialNumberOfNodes);
 
     await registerNodes(nodes, nodesData);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.85":
-  version: 0.1.0-develop.85
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.85"
-  checksum: 10c0/a2e514821f818cfc0da9576a87ad97d165cce38aa52071d75ddc37c9a22707c9f4a5b47b605afc87d359df9f751ac859e8bf5989e6fef196f5acd7e19a92cac7
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.2":
+  version: 0.1.0-keep-public-keys.2
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.2"
+  checksum: 10c0/91f5d6946d938d9ea42a9f0a106e1c49af59bd1e088a82e3a2e1f1e48546bc4c7f4fd6f427184db5d6901f6afe2b899defadee04f0ce4c4318adc98200163656
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.85"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-keep-public-keys.2"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.3":
-  version: 0.1.0-keep-public-keys.3
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.3"
-  checksum: 10c0/9a21b44251e8cf4a96f2dc85f4e16c157bf37a22d441b1b42d08fb31bec23acfc4dc80f69a12b128db75f4ecaaffebb5112356470ecbff35d78d146ce7b8acdb
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.86":
+  version: 0.1.0-develop.86
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.86"
+  checksum: 10c0/3a807eb1e7b3877f19bbe30652cd65f4f0d56b41405e052d8d878439017a13121bb87a57b4b265bbf124caf5346f492babaaedd83928f57839d09539c43718e7
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-keep-public-keys.3"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.86"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.2":
-  version: 0.1.0-keep-public-keys.2
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.2"
-  checksum: 10c0/91f5d6946d938d9ea42a9f0a106e1c49af59bd1e088a82e3a2e1f1e48546bc4c7f4fd6f427184db5d6901f6afe2b899defadee04f0ce4c4318adc98200163656
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.3":
+  version: 0.1.0-keep-public-keys.3
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-keep-public-keys.3"
+  checksum: 10c0/9a21b44251e8cf4a96f2dc85f4e16c157bf37a22d441b1b42d08fb31bec23acfc4dc80f69a12b128db75f4ecaaffebb5112356470ecbff35d78d146ce7b8acdb
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-keep-public-keys.2"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-keep-public-keys.3"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"


### PR DESCRIPTION
Addresses and publicKeys of active nodes don't get deleted and can never be reused by any node.
Adds NodeInfo struct - if we need to add items in the future besides publicKey

Fixes #120