### PR TITLE
add list of allowed users to retrieve fees

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -195,8 +195,10 @@ As described, Active Nodes can be healthy or unhealthy, depending on whether the
 
 #### Staking Main Functions
 
-- `claimAllFee(address payable to)`: Allows Node Owners to collect all pending fees.
-- `claimFee(address payable to, Fair amount)`: Allows Node Owners to withdraw a specific amount of fees.
+- `claimAllFee(NodeId node)`: Allows the sender (if allowed) to collect all pending fees for a node to their own address.
+- `claimFee(NodeId node, Fair amount)`: Allows the sender (if allowed) to withdraw a specific amount of fees for a node to their own address.
+- `addAllowedReceiver(address receiver)`: Allows a Node Owner to add an address to the list of allowed fee receivers for their node.
+- `removeAllowedReceiver(address receiver)`: Allows a Node Owner to remove an address from the list of allowed fee receivers for their node.
 - `nodeCreated(NodeId node)`: internal function that is called by `Nodes` when a new node is created
 - `payReward(NodeId node)`: pays rewards to delegators of the specified nodes
 - `retrieve(NodeId node, Fair value)`: Allows any user to unstake an amount of FAIR from a node.

--- a/SPEC.md
+++ b/SPEC.md
@@ -70,7 +70,8 @@ struct Node {
 - `requestChangeOwner(NodeId nodeId, ...)`: Registers a request to change ownership of a Passive Node.
 - `confirmOwnerChange(NodeId nodeId)`: Confirms a request to change ownership of a Passive Node.
 - `getNode(NodeId nodeId)`: Retrieves a Node.
-- `getNodeId(address nodeAddress)`: Gets the NodeId (if any) for an owner address.
+- `getNodeId(address nodeAddress)`: Gets the NodeId (if registered and not deleted) for an owner address.
+- `getNodeIdUnchecked(address nodeAddress)`: Gets the NodeId (if ever registered) for an owner address.
 - `getActiveNodeIds()`: Returns a list of IDs of all Active Nodes.
 - `getPassiveNodeIds()`: Returns a list of IDs of all Passive Nodes.
 - `getPassiveNodeIdsForAddress(address nodeAddress)`: Returns a list of all Passive Node IDs owned by an address.
@@ -195,8 +196,10 @@ As described, Active Nodes can be healthy or unhealthy, depending on whether the
 
 #### Staking Main Functions
 
-- `claimAllFee(NodeId node)`: Allows the sender (if allowed) to collect all pending fees for a node to their own address.
-- `claimFee(NodeId node, Fair amount)`: Allows the sender (if allowed) to withdraw a specific amount of fees for a node to their own address.
+- `claimAllFees(NodeId node)`: Allows the sender (if allowed) to collect all pending fees for a node to their own address.
+- `claimFees(NodeId node, Fair amount)`: Allows the sender (if allowed) to withdraw a specific amount of fees for a node to their own address.
+- `sendAllFees(address payable to)`: Allows the node owner to send all pending fees for a node to an address.
+- `sendFees(address payable to, Fair amount)`: Allows the node owner to send a specific amount of fees for a node to an address.
 - `addAllowedReceiver(address receiver)`: Allows a Node Owner to add an address to the list of allowed fee receivers for their node.
 - `removeAllowedReceiver(address receiver)`: Allows a Node Owner to remove an address from the list of allowed fee receivers for their node.
 - `nodeCreated(NodeId node)`: internal function that is called by `Nodes` when a new node is created
@@ -234,6 +237,9 @@ FAIR-manager supports setting a maximum stake limit that applies to each nodes t
 - Only node owners can change their fee rate.
 - Only COMMITTEE_ROLE can change node eligibility.
 - Only authorized administrators can set stake limits.
+- Only node owners can send earned fees to other users.
+- Only authorized participants or node owners can claim fees.
+- Only node owners can alter the list of allowed receivers to claim/receive fees.
 
 ### [`Committee.sol`](./contracts/Committee.sol)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,7 +71,6 @@ struct Node {
 - `confirmOwnerChange(NodeId nodeId)`: Confirms a request to change ownership of a Passive Node.
 - `getNode(NodeId nodeId)`: Retrieves a Node.
 - `getNodeId(address nodeAddress)`: Gets the NodeId (if registered and not deleted) for an owner address.
-- `getNodeIdUnchecked(address nodeAddress)`: Gets the NodeId (if ever registered) for an owner address.
 - `getActiveNodeIds()`: Returns a list of IDs of all Active Nodes.
 - `getPassiveNodeIds()`: Returns a list of IDs of all Passive Nodes.
 - `getPassiveNodeIdsForAddress(address nodeAddress)`: Returns a list of all Passive Node IDs owned by an address.

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -24,13 +24,14 @@ import {
     AccessManagedUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 import { ICommittee } from "@skalenetwork/fair-manager-interfaces/ICommittee.sol";
 import {
     INodes,
     NodeId
 } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
-import { IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
 import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
+import { IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
 
 import { TypedMap } from "./structs/typed/TypedMap.sol";
 import { TypedSet } from "./structs/typed/TypedSet.sol";

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -30,6 +30,7 @@ import {
     NodeId
 } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import { IStatus } from "@skalenetwork/fair-manager-interfaces/IStatus.sol";
+import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 
 import { TypedMap } from "./structs/typed/TypedMap.sol";
 import { TypedSet } from "./structs/typed/TypedSet.sol";
@@ -434,7 +435,8 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         address nodeOwner = node.nodeAddress;
         delete nodes[id];
         IStatus statusContract = IStatus(committeeContract.status());
-        if (_isActiveNode(id)) {
+        bool isActive = _isActiveNode(id);
+        if (isActive) {
             assert(_activeNodeIds.remove(id));
             assert(_activeNodesAddressToId.remove(nodeOwner));
             emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
@@ -448,6 +450,12 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             emit PassiveNodeDeleted(id, nodeOwner, node.ip, node.port);
         }
         statusContract.nodeRemoved(id);
+
+        // may send tokens, should be the very last
+        if (isActive) {
+            IStaking stakingContract = IStaking(committeeContract.staking());
+            stakingContract.nodeRemoved(id);
+        }
     }
 
     function _addPassiveNodeId(NodeId nodeId) private {

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -342,11 +342,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     }
 
     function getNodeId(address nodeAddress) external view override returns (NodeId nodeId) {
-        require(
-            _isAddressOfActiveNode(nodeAddress),
-            AddressIsNotAssignedToAnyNode(nodeAddress)
-        );
-        nodeId = _activeNodesAddressToId.get(nodeAddress);
+        nodeId = getNodeIdUnchecked(nodeAddress);
 
         // Address may have been assigned to an active node in the past, but the node may have been deleted
         // We do not allow active nodes with duplicate addresses, even if the old was deleted

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -96,7 +96,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     error IpIsNotAvailable(bytes ip);
     error DomainNameAlreadyTaken(string domainName);
     error NodeDoesNotExist(NodeId nodeId);
-    error NodeWasDeleted(NodeId nodeId);
     error ActiveNodeWasNeverRegistered(NodeId nodeId);
     error PortShouldNotBeZero();
     error SenderIsNotNodeOwner();
@@ -342,11 +341,11 @@ contract Nodes is AccessManagedUpgradeable, INodes {
     }
 
     function getNodeId(address nodeAddress) external view override returns (NodeId nodeId) {
-        nodeId = getNodeIdUnchecked(nodeAddress);
-
-        // Address may have been assigned to an active node in the past, but the node may have been deleted
-        // We do not allow active nodes with duplicate addresses, even if the old was deleted
-        require(_isActiveNode(nodeId), NodeWasDeleted(nodeId));
+        require(
+            _isAddressOfActiveNode(nodeAddress),
+            AddressIsNotAssignedToAnyNode(nodeAddress)
+        );
+        nodeId = _activeNodesAddressToId.get(nodeAddress);
     }
 
     function getPassiveNodeIdsForAddress(
@@ -437,6 +436,7 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         IStatus statusContract = IStatus(committeeContract.status());
         if (_isActiveNode(id)) {
             assert(_activeNodeIds.remove(id));
+            assert(_activeNodesAddressToId.remove(nodeOwner));
             emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
             committeeContract.nodeRemoved(id);
         }

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -437,10 +437,15 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         delete nodes[id];
         IStatus statusContract = IStatus(committeeContract.status());
         bool isActive = _isActiveNode(id);
+        IStaking stakingContract = IStaking(committeeContract.staking());
+
         if (isActive) {
+            emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
+            // flush before removal or rewards are split
+            stakingContract.getRewardWallet(id).flush();
+
             assert(_activeNodeIds.remove(id));
             assert(_activeNodesAddressToId.remove(nodeOwner));
-            emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
             committeeContract.nodeRemoved(id);
         }
         else {
@@ -454,7 +459,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
         // may send tokens, should be the very last
         if (isActive) {
-            IStaking stakingContract = IStaking(committeeContract.staking());
             stakingContract.nodeRemoved(id);
         }
     }

--- a/contracts/RewardWallet.sol
+++ b/contracts/RewardWallet.sol
@@ -24,10 +24,10 @@ pragma solidity ^0.8.24;
 import {
     AccessManagedUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
-import {NodeId} from "@skalenetwork/fair-manager-interfaces/INodes.sol";
+
+import {INodes, NodeId} from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import {IRewardWallet} from "@skalenetwork/fair-manager-interfaces/IRewardWallet.sol";
-import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
-import { INodes } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
+import {IStaking} from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 
 
 contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
@@ -86,7 +86,7 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
     }
 
     // Private
-    function _nodeExists(NodeId nodeId) private view returns (bool) {
+    function _nodeExists(NodeId nodeId) private view returns (bool exists) {
         return nodes.activeNodeExists(nodeId);
     }
 }

--- a/contracts/RewardWallet.sol
+++ b/contracts/RewardWallet.sol
@@ -42,6 +42,11 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
 
     error OwnerNodeDoesNotExist();
 
+    modifier onlyIfNodeExists() {
+        require(_nodeExists(ownerNode), OwnerNodeDoesNotExist());
+        _;
+    }
+
     function initialize(
         address initialAuthority,
         IStaking staking_,
@@ -58,11 +63,7 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
         nodes = nodes_;
     }
 
-    receive() external payable override {
-        require(
-            _nodeExists(ownerNode),
-            OwnerNodeDoesNotExist()
-        );
+    receive() external payable override onlyIfNodeExists() {
         flush();
     }
 

--- a/contracts/RewardWallet.sol
+++ b/contracts/RewardWallet.sol
@@ -79,9 +79,6 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
             else {
                 // Rewards are sent as network rewards
                 // This is a failsafe mechanism, it's expected to never happen under normal conditions
-                // Staking is set during deployment
-                // by Staking contract so the warning is false positive
-                // slither-disable-next-line arbitrary-send-eth
                 payable(staking).sendValue(address(this).balance);
             }
 

--- a/contracts/RewardWallet.sol
+++ b/contracts/RewardWallet.sol
@@ -24,6 +24,9 @@ pragma solidity ^0.8.24;
 import {
     AccessManagedUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import {
+    Address
+} from "@openzeppelin/contracts/utils/Address.sol";
 
 import {INodes, NodeId} from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import {IRewardWallet} from "@skalenetwork/fair-manager-interfaces/IRewardWallet.sol";
@@ -31,12 +34,13 @@ import {IStaking} from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
 
 
 contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
+    using Address for address payable;
+
     IStaking public staking;
     INodes public nodes;
     NodeId public ownerNode;
 
     error OwnerNodeDoesNotExist();
-    error TransferToStakingFailed();
 
     function initialize(
         address initialAuthority,
@@ -78,8 +82,7 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
                 // Staking is set during deployment
                 // by Staking contract so the warning is false positive
                 // slither-disable-next-line arbitrary-send-eth
-                (bool success, ) = address(staking).call{value: address(this).balance}("");
-                require(success, TransferToStakingFailed());
+                payable(staking).sendValue(address(this).balance);
             }
 
         }

--- a/contracts/RewardWallet.sol
+++ b/contracts/RewardWallet.sol
@@ -27,19 +27,38 @@ import {
 import {NodeId} from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import {IRewardWallet} from "@skalenetwork/fair-manager-interfaces/IRewardWallet.sol";
 import { IStaking } from "@skalenetwork/fair-manager-interfaces/IStaking.sol";
+import { INodes } from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 
 
 contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
     IStaking public staking;
+    INodes public nodes;
     NodeId public ownerNode;
 
-    function initialize(address initialAuthority, IStaking staking_, NodeId ownerNode_) external override initializer {
+    error OwnerNodeDoesNotExist();
+    error TransferToStakingFailed();
+
+    function initialize(
+        address initialAuthority,
+        IStaking staking_,
+        INodes nodes_,
+        NodeId ownerNode_
+    )
+        external
+        override
+        initializer
+    {
         __AccessManaged_init(initialAuthority);
         staking = staking_;
         ownerNode = ownerNode_;
+        nodes = nodes_;
     }
 
     receive() external payable override {
+        require(
+            _nodeExists(ownerNode),
+            OwnerNodeDoesNotExist()
+        );
         flush();
     }
 
@@ -47,10 +66,27 @@ contract RewardWallet is AccessManagedUpgradeable, IRewardWallet {
 
     function flush() public override {
         if (address(this).balance > 0) {
-            // Both staking and ownerNode is set during deployment
-            // by Staking contract so the warning is false positive
-            // slither-disable-next-line arbitrary-send-eth
-            staking.payReward{value: address(this).balance}(ownerNode);
+            if (_nodeExists(ownerNode)) {
+                // Both staking and ownerNode is set during deployment
+                // by Staking contract so the warning is false positive
+                // slither-disable-next-line arbitrary-send-eth
+                staking.payReward{value: address(this).balance}(ownerNode);
+            }
+            else {
+                // Rewards are sent as network rewards
+                // This is a failsafe mechanism, it's expected to never happen under normal conditions
+                // Staking is set during deployment
+                // by Staking contract so the warning is false positive
+                // slither-disable-next-line arbitrary-send-eth
+                (bool success, ) = address(staking).call{value: address(this).balance}("");
+                require(success, TransferToStakingFailed());
+            }
+
         }
+    }
+
+    // Private
+    function _nodeExists(NodeId nodeId) private view returns (bool) {
+        return nodes.activeNodeExists(nodeId);
     }
 }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -81,6 +81,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     event Staked(address indexed sender, NodeId indexed node, Fair indexed amount);
     event StakedToNewNode(address indexed sender, NodeId indexed node);
     event StoppedStaking(address indexed sender, NodeId indexed node);
+    event NodeDataRemoved(NodeId indexed node);
     event NodeDisabled(NodeId indexed node);
     event NodeEnabled(NodeId indexed node);
     event StakeLimitUpdated(Fair indexed newLimit);
@@ -158,10 +159,13 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
             FundLibrary.nodeToHolder(node),
             nodeFundBalance
         );
-        require(_disabledNodesBalances.set(node, nodeFundBalance), NodeIsAlreadyDisabled(node));
         totalDisabled = totalDisabled + nodeFundBalance;
+        require(_disabledNodesBalances.set(node, nodeFundBalance), NodeIsAlreadyDisabled(node));
         emit NodeDisabled(node);
-        committee.updateWeight(node, 0);
+
+        if (nodes.activeNodeExists(node)) {
+            committee.updateWeight(node, 0);
+        }
     }
 
     function enable(
@@ -194,26 +198,29 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         assert(_disabledNodesBalances.set(node, FundLibrary.ZERO_FAIR));
     }
 
+    function nodeRemoved(NodeId node) external override restricted {
+        // Committee should disable node first
+        require(!isNodeEnabled(node), NodeIsNotDisabled(node));
+        delete _nodesAllowedReceivers[node];
+        delete _rewardWallets[node];
+        emit NodeDataRemoved(node);
+        _sendFees(
+            node,
+            getEarnedFeeAmount(node),
+            payable(_publicKeyToAddress(nodes.getPublicKey(node)))
+        );
+
+    }
+
     function payReward(
         NodeId node
     )
         external
         payable
         override
+        onlyExistingActiveNode(node)
     {
         require(msg.value > 0, ZeroAmount());
-
-        if (!nodes.activeNodeExists(node)) {
-            require(
-                address(_rewardWallets[node]) == msg.sender,
-                Nodes.NodeDoesNotExist(node)
-            );
-            // Node was deleted
-            // rewards sent by its reward wallet are shared with all stakers
-            emit RewardReceived(msg.sender, msg.value);
-            return;
-        }
-
         bool nodeIsEnabled = !_disabledNodesBalances.contains(node);
         Fair amount = Fair.wrap(msg.value);
         Fair balance = _getTotalBalance() - amount;
@@ -247,9 +254,10 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         require(_stakedNodes[msg.sender].contains(node), ZeroStakeToNode(node));
 
         emit Retrieved(msg.sender, node, value);
+        bool nodeIsEnabled = isNodeEnabled(node);
 
         _pullReward(node);
-        bool nodeIsEnabled = isNodeEnabled(node);
+
         if (nodeIsEnabled) {
             Fair balance = _getTotalBalance();
             _nodesFunds[node].remove(
@@ -412,8 +420,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
     // Public
 
-    function claimFees(NodeId node, Fair amount) public override {
-        // works for deleted Nodes
+    function claimFees(NodeId node, Fair amount) public override onlyExistingActiveNode(node) {
         bool senderIsOwner = msg.sender == _publicKeyToAddress(nodes.getPublicKey(node));
         require(
             _nodesAllowedReceivers[node].contains(msg.sender) || senderIsOwner,
@@ -534,6 +541,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
                 IRewardWallet.initialize.selector,
                 authority(),
                 IStaking(payable(this)),
+                nodes,
                 node
             )
         )));
@@ -541,7 +549,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
 
     function _pullReward(NodeId node) private nonReentrant {
-
+        // safe because getNonPulledReward returns 0 if rewardWallet does not exist
         if (_getNonPulledReward(node) > FundLibrary.ZERO_FAIR) {
             // Reward wallet is considered as a part of Staking contract.
             // The code is trusted and effects are known.
@@ -567,7 +575,11 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     function _getNonPulledReward(NodeId node) private view returns (Fair nonPulledReward) {
+        if (_rewardWallets[node] == IRewardWallet(payable(0))) {
+            return FundLibrary.ZERO_FAIR;
+        }
         return Fair.wrap(address(_rewardWallets[node]).balance);
+
     }
 
     function _getTotalBalance() private view returns (Fair balance) {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -199,6 +199,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     function nodeRemoved(NodeId node) external override restricted {
         // Committee should disable node first
         require(!isNodeEnabled(node), NodeIsNotDisabled(node));
+        _nodesAllowedReceivers[node].clear();
         delete _nodesAllowedReceivers[node];
         delete _rewardWallets[node];
         emit NodeDataRemoved(node);
@@ -417,7 +418,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     // Public
 
     function claimFees(NodeId node, Fair amount) public override onlyExistingActiveNode(node) {
-        bool senderIsOwner = msg.sender == _publicKeyToAddress(nodes.getPublicKey(node));
+        bool senderIsOwner = msg.sender == nodes.getNode(node).nodeAddress;
         require(
             _nodesAllowedReceivers[node].contains(msg.sender) || senderIsOwner,
             NotAllowedToClaimRewards(msg.sender)

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -141,12 +141,10 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     function claimAllFees(NodeId node) external override {
-        // Works for deleted Nodes
         claimFees(node, getEarnedFeeAmount(node));
     }
 
     function sendAllFees(address payable to) external override {
-        // Does not work for deleted Nodes
         sendFees(to, getEarnedFeeAmount(nodes.getNodeId(msg.sender)));
     }
 
@@ -209,7 +207,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
             getEarnedFeeAmount(node),
             payable(_publicKeyToAddress(nodes.getPublicKey(node)))
         );
-
     }
 
     function payReward(

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -129,7 +129,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     function addAllowedReceiver(address receiver) external override {
         NodeId node = nodes.getNodeId(msg.sender);
         bool added = _nodesAllowedReceivers[node].add(receiver);
-        require(added, ReceiverIsAlreadyAllowed(receiver));
+        require(added && receiver != msg.sender, ReceiverIsAlreadyAllowed(receiver));
         emit AllowedReceiverAdded(node, receiver);
     }
 
@@ -141,8 +141,12 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         emit AllowedReceiverRemoved(node, receiver);
     }
 
-    function claimAllFee(NodeId node) external override {
-        claimFee(node, getEarnedFeeAmount(node));
+    function claimAllFees(NodeId node) external override {
+        claimFees(node, getEarnedFeeAmount(node));
+    }
+
+    function sendAllFees(address payable to) external override {
+        sendFees(to, getEarnedFeeAmount(nodes.getNodeIdUnchecked(msg.sender)));
     }
 
     function disable(NodeId node) external override restricted {
@@ -188,7 +192,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         }
         _updateNodeFeeRate(node, DEFAULT_FEE_RATE);
         assert(_disabledNodesBalances.set(node, FundLibrary.ZERO_FAIR));
-        assert(_nodesAllowedReceivers[node].add(nodes.getNode(node).nodeAddress));
     }
 
     function payReward(
@@ -398,41 +401,35 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
     // Public
 
-    function claimFee(NodeId node, Fair amount) public override {
-
-        emit FeeClaimed(node, msg.sender, amount);
+    function claimFees(NodeId node, Fair amount) public override {
+        bool senderIsOwner = msg.sender == _publicKeyToAddress(nodes.getPublicKey(node));
         require(
-            _nodesAllowedReceivers[node].contains(msg.sender),
+            _nodesAllowedReceivers[node].contains(msg.sender) || senderIsOwner,
             NotAllowedToClaimRewards(msg.sender)
         );
-        _pullReward(node);
-        Fair balance = _getTotalBalance();
-        bool nodeIsEnabled = isNodeEnabled(node);
-        if (nodeIsEnabled) {
-            _nodesFunds[node].claimFee(
-                _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node)),
-                amount
-            );
-            _rootFund.remove(
-                balance,
-                FundLibrary.nodeToHolder(node),
-                amount
-            );
-        } else {
-            Fair nodeBalance = _disabledNodesBalances.get(node);
-            _nodesFunds[node].claimFee(
-                nodeBalance,
-                amount
-            );
-            // node is already disabled, should return false
-            assert(!_disabledNodesBalances.set(node, nodeBalance - amount));
-            totalDisabled = totalDisabled - amount;
-        }
+        _sendFees(
+            node,
+            amount,
+            payable(msg.sender)
+        );
+    }
 
-        if (nodeIsEnabled) {
-            committee.updateWeight(node, Credit.unwrap(_getNodeCredits(node)));
+    function sendFees(address payable to, Fair amount) public override {
+        NodeId node = nodes.getNodeIdUnchecked(msg.sender);
+
+        // Node has opted in to allowed receivers, so the destination address must be in the list
+        // Or be the owner
+        if (_hasAllowedReceiver(node)) {
+            require(
+                _nodesAllowedReceivers[node].contains(to) || to == msg.sender,
+                NotAllowedToClaimRewards(to)
+            );
         }
-        payable(msg.sender).sendValue(Fair.unwrap(amount));
+        _sendFees(
+            node,
+            amount,
+            to
+        );
     }
 
     function isNodeEnabled(NodeId node) public view override returns (bool enabled) {
@@ -476,6 +473,44 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     // Private
+
+    function _sendFees(
+        NodeId node,
+        Fair amount,
+        address payable to
+    )
+        private
+    {
+        emit FeeClaimed(node, to, amount);
+        _pullReward(node);
+        Fair balance = _getTotalBalance();
+        bool nodeIsEnabled = isNodeEnabled(node);
+        if (nodeIsEnabled) {
+            _nodesFunds[node].claimFee(
+                _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node)),
+                amount
+            );
+            _rootFund.remove(
+                balance,
+                FundLibrary.nodeToHolder(node),
+                amount
+            );
+        } else {
+            Fair nodeBalance = _disabledNodesBalances.get(node);
+            _nodesFunds[node].claimFee(
+                nodeBalance,
+                amount
+            );
+            // node is already disabled, should return false
+            assert(!_disabledNodesBalances.set(node, nodeBalance - amount));
+            totalDisabled = totalDisabled - amount;
+        }
+
+        if (nodeIsEnabled) {
+            committee.updateWeight(node, Credit.unwrap(_getNodeCredits(node)));
+        }
+        to.sendValue(Fair.unwrap(amount));
+    }
 
     function _deployRewardWallet(NodeId node) private {
         ProxyAdmin proxyAdmin = ProxyAdmin(ERC1967Utils.getAdmin());
@@ -542,6 +577,21 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
                 StakeLimitExceeded(currentNodeStake, amount, stakeLimit)
             );
         }
+    }
+
+    function _hasAllowedReceiver(NodeId node) private view returns (bool result) {
+        return _nodesAllowedReceivers[node].length() > 0;
+    }
+
+    function _publicKeyToAddress(
+        bytes32[2] memory pubKey
+    )
+        private
+        pure
+        returns (address nodeAddress)
+    {
+        bytes32 hash = keccak256(abi.encodePacked(pubKey[0], pubKey[1]));
+        return address(uint160(uint256(hash)));
     }
 
 }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -204,7 +204,12 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         require(msg.value > 0, ZeroAmount());
 
         if (!nodes.activeNodeExists(node)) {
-            // Node was deleted or never registered -> reward is shared with all stakers
+            require(
+                address(_rewardWallets[node]) == msg.sender,
+                Nodes.NodeDoesNotExist(node)
+            );
+            // Node was deleted
+            // rewards sent by its reward wallet are shared with all stakers
             emit RewardReceived(msg.sender, msg.value);
             return;
         }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -251,9 +251,8 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         require(_stakedNodes[msg.sender].contains(node), ZeroStakeToNode(node));
 
         emit Retrieved(msg.sender, node, value);
-        bool nodeIsEnabled = isNodeEnabled(node);
-
         _pullReward(node);
+        bool nodeIsEnabled = isNodeEnabled(node);
 
         if (nodeIsEnabled) {
             Fair balance = _getTotalBalance();
@@ -576,7 +575,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
             return FundLibrary.ZERO_FAIR;
         }
         return Fair.wrap(address(_rewardWallets[node]).balance);
-
     }
 
     function _getTotalBalance() private view returns (Fair balance) {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -87,7 +87,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     event NodeFeeRateUpdated(NodeId indexed node, uint16 oldFeeRate, uint16 newFeeRate);
     event RewardWalletReferenceUpdated(IRewardWallet indexed oldReference, IRewardWallet indexed newReference);
 
-    error CannotRemoveOwner();
     error FeeRateIsIncorrect(uint16 feeRate);
     error OnlyFeeReductionIsAllowed(uint16 currentRate, uint16 newRate);
     error ZeroAmount();
@@ -129,13 +128,12 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     function addAllowedReceiver(address receiver) external override {
         NodeId node = nodes.getNodeId(msg.sender);
         bool added = _nodesAllowedReceivers[node].add(receiver);
-        require(added && receiver != msg.sender, ReceiverIsAlreadyAllowed(receiver));
+        require(added, ReceiverIsAlreadyAllowed(receiver));
         emit AllowedReceiverAdded(node, receiver);
     }
 
     function removeAllowedReceiver(address receiver) external override {
         NodeId node = nodes.getNodeId(msg.sender);
-        require(receiver != msg.sender, CannotRemoveOwner());
         bool removed = _nodesAllowedReceivers[node].remove(receiver);
         require(removed, ReceiverWasNotAllowed(receiver));
         emit AllowedReceiverRemoved(node, receiver);

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -140,11 +140,13 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     function claimAllFees(NodeId node) external override {
+        // Works for deleted Nodes
         claimFees(node, getEarnedFeeAmount(node));
     }
 
     function sendAllFees(address payable to) external override {
-        sendFees(to, getEarnedFeeAmount(nodes.getNodeIdUnchecked(msg.sender)));
+        // Does not work for deleted Nodes
+        sendFees(to, getEarnedFeeAmount(nodes.getNodeId(msg.sender)));
     }
 
     function disable(NodeId node) external override restricted {
@@ -198,9 +200,15 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         external
         payable
         override
-        onlyExistingActiveNode(node)
     {
         require(msg.value > 0, ZeroAmount());
+
+        if (!nodes.activeNodeExists(node)) {
+            // Node was deleted or never registered -> reward is shared with all stakers
+            emit RewardReceived(msg.sender, msg.value);
+            return;
+        }
+
         bool nodeIsEnabled = !_disabledNodesBalances.contains(node);
         Fair amount = Fair.wrap(msg.value);
         Fair balance = _getTotalBalance() - amount;
@@ -400,6 +408,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     // Public
 
     function claimFees(NodeId node, Fair amount) public override {
+        // works for deleted Nodes
         bool senderIsOwner = msg.sender == _publicKeyToAddress(nodes.getPublicKey(node));
         require(
             _nodesAllowedReceivers[node].contains(msg.sender) || senderIsOwner,
@@ -413,7 +422,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     function sendFees(address payable to, Fair amount) public override {
-        NodeId node = nodes.getNodeIdUnchecked(msg.sender);
+        NodeId node = nodes.getNodeId(msg.sender);
 
         // Node has opted in to allowed receivers, so the destination address must be in the list
         // Or be the owner
@@ -528,7 +537,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
     function _pullReward(NodeId node) private nonReentrant {
 
-        if (nodes.activeNodeExists(node) && _getNonPulledReward(node) > FundLibrary.ZERO_FAIR) {
+        if (_getNonPulledReward(node) > FundLibrary.ZERO_FAIR) {
             // Reward wallet is considered as a part of Staking contract.
             // The code is trusted and effects are known.
             // slither-disable-start reentrancy-events

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -37,6 +37,8 @@ import {
 } from "@openzeppelin/contracts/utils/Address.sol";
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 import {ICommittee} from "@skalenetwork/fair-manager-interfaces/ICommittee.sol";
 import {INodes, NodeId} from "@skalenetwork/fair-manager-interfaces/INodes.sol";
 import {IRewardWallet} from "@skalenetwork/fair-manager-interfaces/IRewardWallet.sol";
@@ -50,6 +52,7 @@ import {Credit, FundLibrary, Fair, Holder} from "./utils/Fund.sol";
 
 contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaking {
     using Address for address payable;
+    using EnumerableSet for EnumerableSet.AddressSet;
     using FundLibrary for FundLibrary.Fund;
     using TypedSet for TypedSet.NodeIdSet;
     using TypedMap for TypedMap.HolderToCreditMap;
@@ -62,11 +65,14 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     FundLibrary.Fund private _rootFund;
     mapping (NodeId node => FundLibrary.Fund nodeFund) private _nodesFunds;
     mapping (NodeId node => IRewardWallet rewardWallet) private _rewardWallets;
+    mapping (NodeId node => EnumerableSet.AddressSet allowedReceivers) private _nodesAllowedReceivers;
     mapping (address holder => TypedSet.NodeIdSet nodeIds) private _stakedNodes;
     TypedMap.NodeIdToFairMap private _disabledNodesBalances;
     Fair public stakeLimit;
     uint16 public constant DEFAULT_FEE_RATE = 1000;
 
+    event AllowedReceiverAdded(NodeId indexed node, address indexed receiver);
+    event AllowedReceiverRemoved(NodeId indexed node, address indexed receiver);
     event FeeClaimed(NodeId indexed node, address indexed to, Fair indexed amount);
     event NodeRewardReceived(NodeId indexed node, Fair indexed amount);
     event Retrieved(address indexed sender, NodeId indexed node, Fair indexed amount);
@@ -81,14 +87,17 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     event NodeFeeRateUpdated(NodeId indexed node, uint16 oldFeeRate, uint16 newFeeRate);
     event RewardWalletReferenceUpdated(IRewardWallet indexed oldReference, IRewardWallet indexed newReference);
 
+    error CannotRemoveOwner();
     error FeeRateIsIncorrect(uint16 feeRate);
     error OnlyFeeReductionIsAllowed(uint16 currentRate, uint16 newRate);
     error ZeroAmount();
     error ZeroStakeToNode(NodeId node);
     error NodeIsAlreadyDisabled(NodeId node);
     error NodeIsNotDisabled(NodeId node);
+    error NotAllowedToClaimRewards(address sender);
     error StakeLimitExceeded(Fair currentStake, Fair attemptedStake, Fair limit);
-    error ZeroAddress();
+    error ReceiverIsAlreadyAllowed(address receiver);
+    error ReceiverWasNotAllowed(address receiver);
     error RewardWalletDoesNotExist(NodeId node);
 
     modifier onlyExistingActiveNode(NodeId node) {
@@ -117,8 +126,23 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         emit RewardReceived(msg.sender, msg.value);
     }
 
-    function claimAllFee(address payable to) external override {
-        claimFee(to, getEarnedFeeAmount(nodes.getNodeId(msg.sender)));
+    function addAllowedReceiver(address receiver) external override {
+        NodeId node = nodes.getNodeId(msg.sender);
+        bool added = _nodesAllowedReceivers[node].add(receiver);
+        require(added, ReceiverIsAlreadyAllowed(receiver));
+        emit AllowedReceiverAdded(node, receiver);
+    }
+
+    function removeAllowedReceiver(address receiver) external override {
+        NodeId node = nodes.getNodeId(msg.sender);
+        require(receiver != msg.sender, CannotRemoveOwner());
+        bool removed = _nodesAllowedReceivers[node].remove(receiver);
+        require(removed, ReceiverWasNotAllowed(receiver));
+        emit AllowedReceiverRemoved(node, receiver);
+    }
+
+    function claimAllFee(NodeId node) external override {
+        claimFee(node, getEarnedFeeAmount(node));
     }
 
     function disable(NodeId node) external override restricted {
@@ -164,6 +188,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         }
         _updateNodeFeeRate(node, DEFAULT_FEE_RATE);
         assert(_disabledNodesBalances.set(node, FundLibrary.ZERO_FAIR));
+        assert(_nodesAllowedReceivers[node].add(nodes.getNode(node).nodeAddress));
     }
 
     function payReward(
@@ -373,10 +398,13 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
     // Public
 
-    function claimFee(address payable to, Fair amount) public override {
-        require(to != address(0), ZeroAddress());
-        NodeId node = nodes.getNodeId(msg.sender);
-        emit FeeClaimed(node, to, amount);
+    function claimFee(NodeId node, Fair amount) public override {
+
+        emit FeeClaimed(node, msg.sender, amount);
+        require(
+            _nodesAllowedReceivers[node].contains(msg.sender),
+            NotAllowedToClaimRewards(msg.sender)
+        );
         _pullReward(node);
         Fair balance = _getTotalBalance();
         bool nodeIsEnabled = isNodeEnabled(node);
@@ -404,7 +432,7 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         if (nodeIsEnabled) {
             committee.updateWeight(node, Credit.unwrap(_getNodeCredits(node)));
         }
-        to.sendValue(Fair.unwrap(amount));
+        payable(msg.sender).sendValue(Fair.unwrap(amount));
     }
 
     function isNodeEnabled(NodeId node) public view override returns (bool enabled) {
@@ -467,7 +495,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
 
     function _pullReward(NodeId node) private nonReentrant {
 
-        // getter returns 0 for deleted nodes, even if reward wallet has balance
         if (nodes.activeNodeExists(node) && _getNonPulledReward(node) > FundLibrary.ZERO_FAIR) {
             // Reward wallet is considered as a part of Staking contract.
             // The code is trusted and effects are known.

--- a/migrations/permissions.ts
+++ b/migrations/permissions.ts
@@ -45,7 +45,10 @@ const setupStakeRoles = async (accessManager: FairAccessManager, staking: Stakin
 
     response = await accessManager.setTargetFunctionRole(
         await ethers.resolveAddress(staking),
-        [staking.interface.getFunction("nodeCreated").selector],
+        [
+            staking.interface.getFunction("nodeCreated").selector,
+            staking.interface.getFunction("nodeRemoved").selector
+        ],
         await accessManager.NODES_ROLE()
     );
     await response.wait();

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.9",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.12",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.12",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.88",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.3",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.7",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-develop.87",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.3",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@openzeppelin/upgrades-core": "^1.42.2",
-    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.7",
+    "@skalenetwork/fair-manager-interfaces": "0.1.0-reward-receivers.9",
     "@skalenetwork/skale-contracts-ethers-v6": "1.0.2-develop.68",
     "@skalenetwork/skale-manager-interfaces": "3.2.0-develop.3",
     "@skalenetwork/upgrade-tools": "3.0.0-develop.44",

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -188,7 +188,10 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
-        await expect(nodesContract.getPassiveNodeIdsForAddress(deployer.address))
+        await expect(nodesContract.getNodeIdUnchecked(deployer))
+        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
+
+        await expect(nodesContract.getPassiveNodeIdsForAddress(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
     });
 
@@ -197,11 +200,16 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
+        await expect(nodesContract.getNodeIdUnchecked(deployer))
+        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
+
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
 
         await expect(nodesContract.getNodeId(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
+        await expect(nodesContract.getNodeIdUnchecked(deployer))
+        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
     });
 
 
@@ -465,7 +473,12 @@ describe("Nodes", function () {
         await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000);
         const node = await nodesContract.getNodeId(deployer.address);
         await nodesContract.deleteNode(node);
+
+        // Node was deleted, but address is forever assigned to the node
+        expect(await nodesContract.getActiveNodeIds()).to.not.include(node);
         await expect(nodesContract.getNodeId(deployer.address)).to.be.revertedWithCustomError(nodesContract, "NodeWasDeleted");
+        expect(await nodesContract.getNodeIdUnchecked(deployer.address)).to.be.equal(node);
+
         expect(await nodesContract.getPublicKey(node)).to.be.eql(deployerPubKey);
 
         await expect(nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000))

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -188,7 +188,6 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
-
         await expect(nodesContract.getPassiveNodeIdsForAddress(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
     });
@@ -197,7 +196,6 @@ describe("Nodes", function () {
 
         await expect(nodesContract.getNodeId(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
-
 
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
 

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -188,8 +188,6 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer.address))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
-        await expect(nodesContract.getNodeIdUnchecked(deployer))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
         await expect(nodesContract.getPassiveNodeIdsForAddress(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
@@ -200,15 +198,10 @@ describe("Nodes", function () {
         await expect(nodesContract.getNodeId(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
-        await expect(nodesContract.getNodeIdUnchecked(deployer))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
         await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
 
         await expect(nodesContract.getNodeId(deployer))
-        .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
-
-        await expect(nodesContract.getNodeIdUnchecked(deployer))
         .to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
     });
 
@@ -469,33 +462,27 @@ describe("Nodes", function () {
         .to.be.revertedWithCustomError(nodesContract, "PassiveNodeAlreadyExistsForAddress");
     });
 
-    it("should never allow duplicate public keys from active nodes even after deletion", async function () {
+    it("should allow duplicate public keys from active nodes after deletion", async function () {
         await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000);
         const node = await nodesContract.getNodeId(deployer.address);
         await nodesContract.deleteNode(node);
 
-        // Node was deleted, but address is forever assigned to the node
         expect(await nodesContract.getActiveNodeIds()).to.not.include(node);
-        await expect(nodesContract.getNodeId(deployer.address)).to.be.revertedWithCustomError(nodesContract, "NodeWasDeleted");
-        expect(await nodesContract.getNodeIdUnchecked(deployer.address)).to.be.equal(node);
+        await expect(nodesContract.getNodeId(deployer.address)).to.be.revertedWithCustomError(nodesContract, "AddressIsNotAssignedToAnyNode");
 
         expect(await nodesContract.getPublicKey(node)).to.be.eql(deployerPubKey);
 
-        await expect(nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000))
-        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
+        await nodesContract.registerNode(MOCK_IP_0_BYTES, deployerPubKey , 8000);
 
-        await expect(nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000))
-        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
+        const nodeV2 = await nodesContract.getNodeId(deployer.address);
 
-        expect(await nodesContract.getPublicKey(node)).to.be.eql(deployerPubKey);
+        expect(await nodesContract.getPublicKey(node)).to.be.eql(await nodesContract.getPublicKey(nodeV2));
 
         await nodesContract.connect(user1).registerPassiveNode(MOCK_IP_1_BYTES, 8000);
 
         const [passiveNode] = await nodesContract.getPassiveNodeIdsForAddress(user1.address);
 
-        await expect(nodesContract.connect(user1).requestChangeOwner(passiveNode, deployer.address))
-        .to.be.revertedWithCustomError(nodesContract, "AddressWasAlreadyAssignedToNode");
-
+        await expect(nodesContract.getPublicKey(passiveNode)).to.be.revertedWithCustomError(nodesContract, "ActiveNodeWasNeverRegistered");
         await expect(nodesContract.getPublicKey(passiveNode + 1n)).to.be.revertedWithCustomError(nodesContract, "ActiveNodeWasNeverRegistered");
     });
 

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -182,15 +182,21 @@ describe("Staking", () => {
         .to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
     });
 
-    it("should only be possible to claimFees after node deletion", async () => {
-        const {staking, nodesData, nodes} = await registeredOnlyNodes();
+    it("should not be possible and needed to claimFees and send after node deletion", async () => {
+        const {staking, nodesData, nodes, status} = await whitelistedNodes();
         const [,user] = await ethers.getSigners();
         const initialAmount = ethers.parseEther("3");
-        const amount = ethers.parseEther("1");
+        const amount = ethers.parseEther("2");
         const node = nodesData[22]; // not in the current committee
         const feeRate = 500; // Yes, Eddie, half
         await staking.connect(node.wallet).setFeeRate(feeRate);
         await staking.connect(user).stake(node.id, {value: initialAmount});
+
+        // Node should be eligible
+        await status.connect(node.wallet).alive();
+
+        expect(await staking.isNodeEnabled(node.id)).to.be.eql(true);
+
         (await staking.connect(user).getStakedAmount())
             .should.be.equal(initialAmount);
 
@@ -199,11 +205,18 @@ describe("Staking", () => {
         expect(await staking.getDelegatorsToNode(node.id)).to.be.eql([user.address]);
 
         await staking.connect(user).payReward(node.id, {value: amount});
-
+        expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(amount / 2n);
+        // shall send fees to the node
         await nodes.connect(node.wallet).deleteNode(node.id);
+
+
         expect(await nodes.activeNodeExists(node.id)).to.be.eql(false);
         expect(await staking.isNodeEnabled(node.id)).to.be.eql(false);
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount + amount);
+
+        const fees = amount / 2n;
+        expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(0n);
+        // fees were sent to the node
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount + amount - fees);
         expect(await staking.getDelegatorsToNodeCount(node.id)).to.be.eql(1n);
         expect(await staking.getDelegatorsToNode(node.id)).to.be.eql([user.address]);
 
@@ -212,32 +225,20 @@ describe("Staking", () => {
         (await staking.connect(user).getStakedAmount())
             .should.be.equal(initialAmount - amount / 2n);
 
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount);
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(initialAmount - amount / 2n);
 
         await staking.connect(user).retrieve(node.id, initialAmount - amount / 2n)
             .should.changeEtherBalance(user, initialAmount - amount / 2n);
 
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(amount / 2n);
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(0n);
         expect(await staking.getDelegatorsToNodeCount(node.id)).to.be.eql(0n);
         expect(await staking.getDelegatorsToNode(node.id)).to.be.eql([]);
 
-
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(amount / 2n);
-
-        // Set some balance to reward wallet
-        await setBalance(await staking.getRewardWallet(node.id), 100);
-
-        // allows to collect fees after deletion, even with reward wallet having balance
-        await staking.connect(node.wallet).claimFees(node.id, amount / 4n).should.changeEtherBalance(node.wallet.address, amount / 4n);
+        // does not allow to collect fees after deletion
+        await expect(staking.connect(node.wallet).claimAllFees(node.id)).to.be.revertedWithCustomError(nodes, "NodeDoesNotExist");
 
         // does not allow to send fees after deletion
-        await expect(staking.connect(node.wallet).sendFees(node.wallet, amount / 4n)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
-
-        const leftovers = await staking.getNodeTotalStake(node.id);
-        await staking.connect(node.wallet).claimAllFees(node.id).should.changeEtherBalance(node.wallet.address, leftovers);
-
-        // rewards were flushed and shared to all stakers, nothing left
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(0n);
+        await expect(staking.connect(node.wallet).sendAllFees(node.wallet)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
     });
 
     it("should apply validator fee on rewards", async () => {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -135,7 +135,7 @@ describe("Staking", () => {
         await nodes.connect(node.wallet).deleteNode(node.id);
 
         // Should not allow changing allowed list after node deletion
-        await staking.connect(node.wallet).removeAllowedReceiver(node.wallet).should.be.revertedWithCustomError(nodes, "NodeWasDeleted");
+        await staking.connect(node.wallet).removeAllowedReceiver(node.wallet).should.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
     });
 
     it("only authorized users should be able to claim, send or receive rewards", async () => {
@@ -182,7 +182,7 @@ describe("Staking", () => {
         .to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
     });
 
-    it("should be possible to retrieve stake and fees from deleted Node", async () => {
+    it("should only be possible to claimFees after node deletion", async () => {
         const {staking, nodesData, nodes} = await registeredOnlyNodes();
         const [,user] = await ethers.getSigners();
         const initialAmount = ethers.parseEther("3");
@@ -230,10 +230,14 @@ describe("Staking", () => {
         // allows to collect fees after deletion, even with reward wallet having balance
         await staking.connect(node.wallet).claimFees(node.id, amount / 4n).should.changeEtherBalance(node.wallet.address, amount / 4n);
 
-        // allows to send fees after deletion, even with reward wallet having balance
-        await staking.connect(node.wallet).sendFees(node.wallet, amount / 4n).should.changeEtherBalance(node.wallet.address, amount / 4n);
+        // does not allow to send fees after deletion
+        await expect(staking.connect(node.wallet).sendFees(node.wallet, amount / 4n)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
 
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(100n); // 100 wei lost in reward wallet
+        const leftovers = await staking.getNodeTotalStake(node.id);
+        await staking.connect(node.wallet).claimAllFees(node.id).should.changeEtherBalance(node.wallet.address, leftovers);
+
+        // rewards were flushed and shared to all stakers, nothing left
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(0n);
     });
 
     it("should apply validator fee on rewards", async () => {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -117,6 +117,27 @@ describe("Staking", () => {
         expect(await staking.getDelegatorsToNode(node)).to.be.eql([]);
     });
 
+    it("should allow only allowed node owner to change allowed list", async () => {
+        const {staking, nodesData, nodes} = await registeredOnlyNodes();
+        const [,hacker] = await ethers.getSigners();
+        const node = nodesData[22]; // not in the current committee
+
+        // only node owner can add receivers
+        await expect(staking.addAllowedReceiver(hacker.address)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
+
+        // node owner can register itself
+        await expect(staking.connect(node.wallet).addAllowedReceiver(node.wallet)).to.emit(staking, "AllowedReceiverAdded");
+
+        // node owner can remove itself
+        await expect(staking.connect(node.wallet).removeAllowedReceiver(node.wallet))
+        .to.emit(staking, "AllowedReceiverRemoved");
+
+        await nodes.connect(node.wallet).deleteNode(node.id);
+
+        // Should not allow changing allowed list after node deletion
+        await staking.connect(node.wallet).removeAllowedReceiver(node.wallet).should.be.revertedWithCustomError(nodes, "NodeWasDeleted");
+    });
+
     it("only authorized users should be able to claim, send or receive rewards", async () => {
         const {staking, nodesData, nodes} = await registeredOnlyNodes();
         const [,user, allowedReceiver] = await ethers.getSigners();
@@ -159,10 +180,8 @@ describe("Staking", () => {
         // allowed receivers cannot send fees, only claim
         await expect(staking.connect(allowedReceiver).sendFees(allowedReceiver, tinyAmount))
         .to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
-
-
-
     });
+
     it("should be possible to retrieve stake and fees from deleted Node", async () => {
         const {staking, nodesData, nodes} = await registeredOnlyNodes();
         const [,user] = await ethers.getSigners();
@@ -381,47 +400,6 @@ describe("Staking", () => {
             .should.be.equal(0n);
         (await staking.getStakedAmountFor(user))
             .should.be.equal(amount2 + node2Reward);
-    });
-
-    it("should allow only allowed receivers to claim fees", async () => {
-
-        const {staking, nodesData, nodes} = await registeredOnlyNodes();
-        const [,user, receiver] = await ethers.getSigners();
-        const initialAmount = ethers.parseEther("3");
-        const amount = ethers.parseEther("1");
-        const node = nodesData[22]; // not in the current committee
-        const feeRate = 500; // Yes, Eddie, half
-        await staking.connect(node.wallet).setFeeRate(feeRate);
-        await staking.connect(user).stake(node.id, {value: initialAmount});
-        await staking.connect(user).payReward(node.id, {value: amount});
-
-        // only node owner can add receivers
-        await expect(staking.addAllowedReceiver(receiver.address)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
-
-        await staking.connect(node.wallet).addAllowedReceiver(receiver.address);
-
-        // node owner can register itself
-        await expect(staking.connect(node.wallet).addAllowedReceiver(node.wallet)).to.emit(staking, "AllowedReceiverAdded");
-
-        // node owner can remove itself
-        await expect(staking.connect(node.wallet).removeAllowedReceiver(node.wallet))
-        .to.emit(staking, "AllowedReceiverRemoved");
-
-        // unauthorized users cannot claim fees
-        await expect(staking.connect(user).claimAllFees(node.id)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
-
-
-        // should allow receiver to collect fees
-        const unclaimedFees = await staking.getEarnedFeeAmount(node.id);
-        await staking.connect(receiver).claimAllFees(node.id).should.changeEtherBalance(receiver, unclaimedFees);
-
-        expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(0n);
-
-        await nodes.connect(node.wallet).deleteNode(node.id);
-
-        // Should not allow changing allowed list after node deletion
-        await staking.connect(node.wallet).removeAllowedReceiver(receiver).should.be.revertedWithCustomError(nodes, "NodeWasDeleted");
-
     });
 
     it("should allow to retrieve from a node from committee", async () => {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -167,6 +167,9 @@ describe("Staking", () => {
         // TODO: uncomment after fixing the issue with claiming fees from deleted nodes
         // await staking.connect(node.wallet).claimFee(node.wallet.address, amount / 2n).should.changeEtherBalance(node.wallet.address, amount / 2n);
         // expect(await staking.getNodeTotalStake(node.id)).to.be.eql(100n); // 100 wei lost in reward wallet
+        await staking.connect(node.wallet).claimAllFee(node.id).should.changeEtherBalance(node.wallet.address, amount / 2n);
+
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(0n); // 100 wei lost in reward wallet
     });
 
     it("should apply validator fee on rewards", async () => {
@@ -202,7 +205,7 @@ describe("Staking", () => {
         expect(await staking.getDelegatorsToNodeCount(node)).to.be.eql(0n);
         expect(await staking.getDelegatorsToNode(node)).to.be.eql([]);
 
-        await staking.connect(nodeWallet).claimAllFee(nodeWallet.address)
+        await staking.connect(nodeWallet).claimAllFee(node)
             .should.changeEtherBalance(nodeWallet, reward / 2n);
 
         (await staking.getEarnedFeeAmount(node))
@@ -289,7 +292,7 @@ describe("Staking", () => {
         (await staking.getStakedToNodeAmountFor(node2, user))
             .should.be.equal(amount2 + node2Reward);
 
-        await staking.connect(node1Wallet).claimAllFee(node1Wallet.address)
+        await staking.connect(node1Wallet).claimAllFee(node1)
             .should.changeEtherBalance(node1Wallet, node1Fee);
         // root pool:
         //     total: 13 Fair, 4.(3) credits
@@ -333,6 +336,48 @@ describe("Staking", () => {
             .should.be.equal(0n);
         (await staking.getStakedAmountFor(user))
             .should.be.equal(amount2 + node2Reward);
+    });
+
+    it("should allow only allowed receivers to claim fees", async () => {
+
+        const {staking, nodesData, nodes} = await registeredOnlyNodes();
+        const [,user, receiver] = await ethers.getSigners();
+        const initialAmount = ethers.parseEther("3");
+        const amount = ethers.parseEther("1");
+        const node = nodesData[22]; // not in the current committee
+        const feeRate = 500; // Yes, Eddie, half
+        await staking.connect(node.wallet).setFeeRate(feeRate);
+        await staking.connect(user).stake(node.id, {value: initialAmount});
+        await staking.connect(user).payReward(node.id, {value: amount});
+
+        // only node owner can add receivers
+        await expect(staking.addAllowedReceiver(receiver.address)).to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
+
+        await staking.connect(node.wallet).addAllowedReceiver(receiver.address);
+
+        // node owner is registered by default
+        await expect(staking.connect(node.wallet).addAllowedReceiver(node.wallet))
+        .to.be.revertedWithCustomError(staking, "ReceiverIsAlreadyAllowed")
+
+        // node owner cannot be removed
+        await expect(staking.connect(node.wallet).removeAllowedReceiver(node.wallet))
+        .to.be.revertedWithCustomError(staking, "CannotRemoveOwner")
+
+        // unauthorized users cannot claim fees
+        await expect(staking.connect(user).claimAllFee(node.id)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
+
+
+        // should allow receiver to collect fees
+        const unclaimedFees = await staking.getEarnedFeeAmount(node.id);
+        await staking.connect(receiver).claimAllFee(node.id).should.changeEtherBalance(receiver, unclaimedFees);
+
+        expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(0n);
+
+        await nodes.connect(node.wallet).deleteNode(node.id);
+
+        // Should not allow changing allowed list after node deletion
+        await staking.connect(node.wallet).removeAllowedReceiver(receiver).should.be.reverted;
+
     });
 
     it("should allow to retrieve from a node from committee", async () => {
@@ -402,7 +447,7 @@ describe("Staking", () => {
             const currentFee = node === disabledNode ? 0 : amount;
             (await staking.getEarnedFeeAmount(node.id))
                 .should.be.equal(currentFee);
-            (await staking.connect(node.wallet).claimAllFee(node.wallet.address))
+            (await staking.connect(node.wallet).claimAllFee(node.id))
                 .should.changeEtherBalance(node.wallet, currentFee);
         }
 
@@ -433,7 +478,7 @@ describe("Staking", () => {
             const currentFee = node === disabledNode ? amount : amount * 2n;
             (await staking.getEarnedFeeAmount(node.id))
                 .should.be.approximately(currentFee, tolerance);
-            (await staking.connect(node.wallet).claimAllFee(node.wallet.address))
+            (await staking.connect(node.wallet).claimAllFee(node.id))
                 .should.changeEtherBalance(node.wallet, currentFee);
         }
     });

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -117,6 +117,52 @@ describe("Staking", () => {
         expect(await staking.getDelegatorsToNode(node)).to.be.eql([]);
     });
 
+    it("only authorized users should be able to claim, send or receive rewards", async () => {
+        const {staking, nodesData, nodes} = await registeredOnlyNodes();
+        const [,user, allowedReceiver] = await ethers.getSigners();
+        const initialAmount = ethers.parseEther("3");
+        const amount = ethers.parseEther("1");
+        const node = nodesData[22]; // not in the current committee
+        const feeRate = 500; // Yes, Eddie, half
+        await staking.connect(node.wallet).setFeeRate(feeRate);
+        await staking.connect(user).stake(node.id, {value: initialAmount});
+        (await staking.connect(user).getStakedAmount())
+            .should.be.equal(initialAmount);
+
+        await staking.connect(user).payReward(node.id, {value: amount});
+
+        // Node has 0.5 FAIR to collect in Fees
+        const tinyAmount = 10n;
+
+        // Node owner can send fees to anyone if it has not set any allowed receiver
+        await expect(staking.connect(node.wallet).sendFees(user, tinyAmount)).to.changeEtherBalance(user, tinyAmount);
+
+        // Node owner can always claim fees
+        await expect(staking.connect(node.wallet).claimFees(node.id, tinyAmount)).to.changeEtherBalance(node.wallet, tinyAmount);
+
+        await expect(staking.connect(allowedReceiver).claimFees(node.id, tinyAmount)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
+
+        await staking.connect(node.wallet).addAllowedReceiver(allowedReceiver);
+
+        // Node owner can now only send fees to allowed receivers
+        await expect(staking.connect(node.wallet).sendFees(user, tinyAmount)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
+
+        // allowed receiver can claim fees
+        await expect(staking.connect(allowedReceiver).claimFees(node.id, tinyAmount)).to.changeEtherBalance(allowedReceiver, tinyAmount);
+
+        // allowed receiver can receive fees
+        await expect(staking.connect(node.wallet).sendFees(allowedReceiver, tinyAmount)).to.changeEtherBalance(allowedReceiver, tinyAmount);
+
+        // Node owner can always receive fees
+        await expect(staking.connect(node.wallet).sendFees(node.wallet, tinyAmount)).to.changeEtherBalance(node.wallet, tinyAmount);
+
+        // allowed receivers cannot send fees, only claim
+        await expect(staking.connect(allowedReceiver).sendFees(allowedReceiver, tinyAmount))
+        .to.be.revertedWithCustomError(nodes, "AddressIsNotAssignedToAnyNode");
+
+
+
+    });
     it("should be possible to retrieve stake and fees from deleted Node", async () => {
         const {staking, nodesData, nodes} = await registeredOnlyNodes();
         const [,user] = await ethers.getSigners();
@@ -163,13 +209,12 @@ describe("Staking", () => {
         await setBalance(await staking.getRewardWallet(node.id), 100);
 
         // allows to collect fees after deletion, even with reward wallet having balance
+        await staking.connect(node.wallet).claimFees(node.id, amount / 4n).should.changeEtherBalance(node.wallet.address, amount / 4n);
 
-        // TODO: uncomment after fixing the issue with claiming fees from deleted nodes
-        // await staking.connect(node.wallet).claimFee(node.wallet.address, amount / 2n).should.changeEtherBalance(node.wallet.address, amount / 2n);
-        // expect(await staking.getNodeTotalStake(node.id)).to.be.eql(100n); // 100 wei lost in reward wallet
-        await staking.connect(node.wallet).claimAllFee(node.id).should.changeEtherBalance(node.wallet.address, amount / 2n);
+        // allows to send fees after deletion, even with reward wallet having balance
+        await staking.connect(node.wallet).sendFees(node.wallet, amount / 4n).should.changeEtherBalance(node.wallet.address, amount / 4n);
 
-        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(0n); // 100 wei lost in reward wallet
+        expect(await staking.getNodeTotalStake(node.id)).to.be.eql(100n); // 100 wei lost in reward wallet
     });
 
     it("should apply validator fee on rewards", async () => {
@@ -205,7 +250,7 @@ describe("Staking", () => {
         expect(await staking.getDelegatorsToNodeCount(node)).to.be.eql(0n);
         expect(await staking.getDelegatorsToNode(node)).to.be.eql([]);
 
-        await staking.connect(nodeWallet).claimAllFee(node)
+        await staking.connect(nodeWallet).claimAllFees(node)
             .should.changeEtherBalance(nodeWallet, reward / 2n);
 
         (await staking.getEarnedFeeAmount(node))
@@ -292,7 +337,7 @@ describe("Staking", () => {
         (await staking.getStakedToNodeAmountFor(node2, user))
             .should.be.equal(amount2 + node2Reward);
 
-        await staking.connect(node1Wallet).claimAllFee(node1)
+        await staking.connect(node1Wallet).claimAllFees(node1)
             .should.changeEtherBalance(node1Wallet, node1Fee);
         // root pool:
         //     total: 13 Fair, 4.(3) credits
@@ -364,19 +409,19 @@ describe("Staking", () => {
         .to.be.revertedWithCustomError(staking, "CannotRemoveOwner")
 
         // unauthorized users cannot claim fees
-        await expect(staking.connect(user).claimAllFee(node.id)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
+        await expect(staking.connect(user).claimAllFees(node.id)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");
 
 
         // should allow receiver to collect fees
         const unclaimedFees = await staking.getEarnedFeeAmount(node.id);
-        await staking.connect(receiver).claimAllFee(node.id).should.changeEtherBalance(receiver, unclaimedFees);
+        await staking.connect(receiver).claimAllFees(node.id).should.changeEtherBalance(receiver, unclaimedFees);
 
         expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(0n);
 
         await nodes.connect(node.wallet).deleteNode(node.id);
 
         // Should not allow changing allowed list after node deletion
-        await staking.connect(node.wallet).removeAllowedReceiver(receiver).should.be.reverted;
+        await staking.connect(node.wallet).removeAllowedReceiver(receiver).should.be.revertedWithCustomError(nodes, "NodeWasDeleted");
 
     });
 
@@ -447,7 +492,7 @@ describe("Staking", () => {
             const currentFee = node === disabledNode ? 0 : amount;
             (await staking.getEarnedFeeAmount(node.id))
                 .should.be.equal(currentFee);
-            (await staking.connect(node.wallet).claimAllFee(node.id))
+            (await staking.connect(node.wallet).claimAllFees(node.id))
                 .should.changeEtherBalance(node.wallet, currentFee);
         }
 
@@ -478,7 +523,7 @@ describe("Staking", () => {
             const currentFee = node === disabledNode ? amount : amount * 2n;
             (await staking.getEarnedFeeAmount(node.id))
                 .should.be.approximately(currentFee, tolerance);
-            (await staking.connect(node.wallet).claimAllFee(node.id))
+            (await staking.connect(node.wallet).claimAllFees(node.id))
                 .should.changeEtherBalance(node.wallet, currentFee);
         }
     });
@@ -689,8 +734,6 @@ describe("Staking", () => {
 
         expect(await staking.getNodeTotalStake(node)).to.be.equal(2n * sufficientlyHighAmount + 1n);
 
-
-        // If we withdraw the other way around, 1wei will be lost :O //TODO: check this
         await staking.connect(hacker).retrieve(node, sufficientlyHighAmount + 1n);
         await staking.connect(user).retrieve(node, sufficientlyHighAmount);
 

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -400,13 +400,12 @@ describe("Staking", () => {
 
         await staking.connect(node.wallet).addAllowedReceiver(receiver.address);
 
-        // node owner is registered by default
-        await expect(staking.connect(node.wallet).addAllowedReceiver(node.wallet))
-        .to.be.revertedWithCustomError(staking, "ReceiverIsAlreadyAllowed")
+        // node owner can register itself
+        await expect(staking.connect(node.wallet).addAllowedReceiver(node.wallet)).to.emit(staking, "AllowedReceiverAdded");
 
-        // node owner cannot be removed
+        // node owner can remove itself
         await expect(staking.connect(node.wallet).removeAllowedReceiver(node.wallet))
-        .to.be.revertedWithCustomError(staking, "CannotRemoveOwner")
+        .to.emit(staking, "AllowedReceiverRemoved");
 
         // unauthorized users cannot claim fees
         await expect(staking.connect(user).claimAllFees(node.id)).to.be.revertedWithCustomError(staking, "NotAllowedToClaimRewards");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.12":
-  version: 0.1.0-reward-receivers.12
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.12"
-  checksum: 10c0/62a93030e21ced29ebda1297619f83b2847c4ae051150078173f95ba446dcb95109d165eb940ebf434ba998c92d64b0b5ff1083db714c65901f128fa039bd5e0
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.88":
+  version: 0.1.0-develop.88
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.88"
+  checksum: 10c0/354bc5581d5581df81f54c112098e4c107b5aecaba3b82dcdc5ff5115ec2bf1cbfcc06f3d1351c5290cdd849fe8a5e80766254940c6cc722703da3493556229e
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.12"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.88"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.9":
-  version: 0.1.0-reward-receivers.9
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.9"
-  checksum: 10c0/7cba12e76a95b064774489fb0449cc85270980f849f8e9a5cc492ab3ddeac0e76b29e71a0987bc6b76235f997a65be146335f7f6bd08d10cff909e0145c90bce
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.12":
+  version: 0.1.0-reward-receivers.12
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.12"
+  checksum: 10c0/62a93030e21ced29ebda1297619f83b2847c4ae051150078173f95ba446dcb95109d165eb940ebf434ba998c92d64b0b5ff1083db714c65901f128fa039bd5e0
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.9"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.12"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.87":
-  version: 0.1.0-develop.87
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-develop.87"
-  checksum: 10c0/0b1f9c9dde9b7603effe69c07a3bf5a137a7817474d5f33940bd1be4150b6fd1873c3469a6f01798fa42aa7fd6ded6c1ab9c781a9e6d7e5a94302012e1d2a144
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.3":
+  version: 0.1.0-reward-receivers.3
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.3"
+  checksum: 10c0/e00ed356ca99d5a600befeea33ee878ee009c8528523f8b42a58b74880017022c61987ba93a0c53b64604aca8c51c2efd229a2e01d8a0fbbe54efacc4a4c2f64
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-develop.87"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.3"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.3":
-  version: 0.1.0-reward-receivers.3
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.3"
-  checksum: 10c0/e00ed356ca99d5a600befeea33ee878ee009c8528523f8b42a58b74880017022c61987ba93a0c53b64604aca8c51c2efd229a2e01d8a0fbbe54efacc4a4c2f64
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.7":
+  version: 0.1.0-reward-receivers.7
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.7"
+  checksum: 10c0/050572d11da4049c223ad5fc613b20e6b13de5e69f13acf52bcc3103ee854f247461c1e5651304fc565b6c928148def44a6daf3b7d12f2d205586b99a92ec9e6
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.3"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.7"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.7":
-  version: 0.1.0-reward-receivers.7
-  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.7"
-  checksum: 10c0/050572d11da4049c223ad5fc613b20e6b13de5e69f13acf52bcc3103ee854f247461c1e5651304fc565b6c928148def44a6daf3b7d12f2d205586b99a92ec9e6
+"@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.9":
+  version: 0.1.0-reward-receivers.9
+  resolution: "@skalenetwork/fair-manager-interfaces@npm:0.1.0-reward-receivers.9"
+  checksum: 10c0/7cba12e76a95b064774489fb0449cc85270980f849f8e9a5cc492ab3ddeac0e76b29e71a0987bc6b76235f997a65be146335f7f6bd08d10cff909e0145c90bce
   languageName: node
   linkType: hard
 
@@ -5095,7 +5095,7 @@ __metadata:
     "@openzeppelin/contracts-upgradeable": "npm:^5.3.0"
     "@openzeppelin/hardhat-upgrades": "npm:^3.9.0"
     "@openzeppelin/upgrades-core": "npm:^1.42.2"
-    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.7"
+    "@skalenetwork/fair-manager-interfaces": "npm:0.1.0-reward-receivers.9"
     "@skalenetwork/skale-contracts-ethers-v6": "npm:1.0.2-develop.68"
     "@skalenetwork/skale-manager-interfaces": "npm:3.2.0-develop.3"
     "@skalenetwork/upgrade-tools": "npm:3.0.0-develop.44"


### PR DESCRIPTION
- Old claimFee functionality is now transfered to sendFees().
- claimFees can be called by node owner or allowed users, and sends tokens to the msg.sender.
- sendFees verifies the 'to' input field if the node has opted to add allowed users. If the list is empty, it will allow to send to any address.
- Node deletion now transfers all remaining fees to the nodeAddress, thus claim and send fees after deletion is not possible or required.
- RewardWallet address and allowed users data is deleted on node deletion.
- Reward wallet does not receive funds if the node was deleted.
- If wallet has remaining funds, and node was deleted, these are distributed as a network reward on flush() - thought only possible if skaled assigns funds

Fixes #122