### PR TITLE
Fix panic error during Status.alive

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -179,9 +179,9 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         restricted
         onlyExistingActiveNode(node)
     {
+        _pullReward(node);
         (bool wasDisabled, Fair value) = _disabledNodesBalances.tryGet(node);
         require(wasDisabled, NodeIsNotDisabled(node));
-        _pullReward(node);
         Fair balance = _getTotalBalance();
         _rootFund.supply(
             balance,

--- a/contracts/utils/Fund.sol
+++ b/contracts/utils/Fund.sol
@@ -133,6 +133,10 @@ library FundLibrary {
         _processBalanceChange(fund, balanceBeforeSupply);
         Fair balanceBefore = getBalance(fund, balanceBeforeSupply, holder);
         Credit credits = _toCreditsRoundedDown(fund, balanceBeforeSupply, amount);
+        Fair delayedReward = ZERO_FAIR;
+        if (fund.totalCredits == ZERO_CREDIT) {
+            delayedReward = balanceBeforeSupply;
+        }
         (bool holderExists, Credit holderCredits) = fund.credits.tryGet(holder);
         // If holder does not exist, it is added with the credits.
         // If it does exist, set() must return false and value is updated.
@@ -142,7 +146,7 @@ library FundLibrary {
         }
         fund.lastBalance = balanceBeforeSupply + amount;
         Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
-        _checkAllowedError(balanceBefore, balanceAfter, amount);
+        _checkAllowedError(balanceBefore, balanceAfter, amount + delayedReward);
     }
 
     function getBalance(
@@ -271,6 +275,12 @@ library FundLibrary {
     {
         if (balance == ZERO_FAIR) {
             return Credit.wrap(Fair.unwrap(amount) * CREDIT_PRECISION);
+        }
+        if (fund.totalCredits == ZERO_CREDIT) {
+            // Balance is positive but amount of shares is still zero.
+            // Reward was received before somebody joined the fund.
+            // Give away the reward to first holder joined because there is no one else.
+            return Credit.wrap(Fair.unwrap(amount + balance) * CREDIT_PRECISION);
         }
         return Credit.wrap(
             Math.mulDiv(

--- a/contracts/utils/Fund.sol
+++ b/contracts/utils/Fund.sol
@@ -70,7 +70,7 @@ library FundLibrary {
         internal
     {
         _processBalanceChange(fund, balanceBeforeClaim);
-        
+
         Credit credits = _toCreditsRoundedUp(fund, balanceBeforeClaim, amount);
         if (fund.ownerCredits < credits) {
             revert NotEnoughFee(_toFairRoundedDown(fund, balanceBeforeClaim, ZERO_CREDIT, fund.ownerCredits));
@@ -131,7 +131,7 @@ library FundLibrary {
         internal
     {
         _processBalanceChange(fund, balanceBeforeSupply);
-        Fair balanceBefore = getBalance(fund, balanceBeforeSupply, holder);
+        Fair holderBalanceBefore = getBalance(fund, balanceBeforeSupply, holder);
         Credit credits = _toCreditsRoundedDown(fund, balanceBeforeSupply, amount);
         Fair delayedReward = ZERO_FAIR;
         if (fund.totalCredits == ZERO_CREDIT) {
@@ -146,7 +146,7 @@ library FundLibrary {
         }
         fund.lastBalance = balanceBeforeSupply + amount;
         Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
-        _checkAllowedError(balanceBefore, balanceAfter, amount + delayedReward);
+        _checkAllowedError(holderBalanceBefore, balanceAfter, amount + delayedReward);
     }
 
     function getBalance(
@@ -254,7 +254,7 @@ library FundLibrary {
         view
         returns (Credit fee)
     {
-        if (balance > fund.lastBalance) {
+        if (balance > fund.lastBalance && fund.feeRate > 0) {
             Fair balanceChange = balance - fund.lastBalance;
             Fair feeInFair = Fair.wrap(
                 Fair.unwrap(balanceChange) * fund.feeRate / 1000
@@ -324,14 +324,15 @@ library FundLibrary {
         view
         returns (Fair fair)
     {
-        if (fund.totalCredits == ZERO_CREDIT) {
+        Credit totalCreditsWithUncountedFee = fund.totalCredits + uncountedFee;
+        if (totalCreditsWithUncountedFee == ZERO_CREDIT) {
             return ZERO_FAIR;
         }
         return Fair.wrap(
             Math.mulDiv(
                 Fair.unwrap(balance),
                 Credit.unwrap(amount),
-                Credit.unwrap(fund.totalCredits + uncountedFee),
+                Credit.unwrap(totalCreditsWithUncountedFee),
                 Math.Rounding.Floor
             )
         );

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1038,4 +1038,69 @@ describe("Staking", () => {
         await setBalance(await ethers.resolveAddress(staking), ethers.parseEther("2"));
         await status.connect(node.wallet).alive();
     });
+
+    it("should correctly process delayed rewards when fee rate is 0", async () => {
+        const {nodesData: [node], staking} = await registeredOnlyNodes();
+        const amount = ethers.parseEther("1");
+        await staking.connect(node.wallet).setFeeRate(0);
+
+        (await staking.getStakedAmount())
+            .should.be.equal(0n);
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(0n);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(0n);
+
+        // Pay reward to a node without stake
+        await setBalance(await staking.getRewardWallet(node.id), amount);
+
+        (await staking.getStakedAmount())
+            .should.be.equal(0n);
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(amount);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(0n);
+
+        // Stake to the node with reward waiting
+        await staking.stake(node.id, {value: amount});
+
+        (await staking.getStakedAmount())
+            .should.be.equal(amount + amount); // stake + delayed reward
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(amount + amount);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(0n);
+    });
+
+    it("should correctly process delayed rewards when fee rate is greater than 0", async () => {
+        const {nodesData: [node], staking} = await registeredOnlyNodes();
+        const amount = ethers.parseEther("1");
+        await staking.connect(node.wallet).setFeeRate(500); // 50%
+
+        (await staking.getStakedAmount())
+            .should.be.equal(0n);
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(0n);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(0n);
+
+        // Pay reward to a node without stake
+        await setBalance(await staking.getRewardWallet(node.id), amount);
+
+        (await staking.getStakedAmount())
+            .should.be.equal(0n);
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(amount);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(amount);
+
+        await staking.stake(node.id, {value: amount});
+
+        (await staking.getStakedAmount())
+            .should.be.equal(amount);
+        (await staking.getNodeTotalStake(node.id))
+            .should.be.equal(amount + amount);
+        (await staking.getEarnedFeeAmount(node.id))
+            .should.be.equal(amount);
+    });
 });

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1029,4 +1029,13 @@ describe("Staking", () => {
         expect(stakeBefore).to.be.greaterThan(stakeAfter);
         expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(0n);
     });
+
+    it("should allow alive() to enable node after receiving rewards", async () => {
+        const {nodesData, staking, status} = await whitelistedNodes();
+        const [node] = nodesData;
+        const rewardWallet = await staking.getRewardWallet(node.id);
+        await setBalance(rewardWallet, ethers.parseEther("3"));
+        await setBalance(await ethers.resolveAddress(staking), ethers.parseEther("2"));
+        await status.connect(node.wallet).alive();
+    });
 });


### PR DESCRIPTION
- consider `RewardWallet` balance in the `enable` function
- pay rewards from the period when there are no eligible nodes to first good node
- update error check to work correctly with delayed rewards