### PR TITLE
Fix deletion of Nodes

### DIFF
--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -434,12 +434,17 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_usedDomainNames.remove(newName));
         }
         address nodeOwner = node.nodeAddress;
+        bytes memory ip = node.ip;
+        uint16 port = node.port;
+        delete nodes[id];
+
+
         IStatus statusContract = IStatus(committeeContract.status());
         bool isActive = _isActiveNode(id);
         IStaking stakingContract = IStaking(committeeContract.staking());
 
         if (isActive) {
-            emit ActiveNodeDeleted(id, nodeOwner, node.ip, node.port);
+            emit ActiveNodeDeleted(id, nodeOwner, ip, port);
             // flush before removal or rewards are split
             stakingContract.getRewardWallet(id).flush();
 
@@ -452,14 +457,11 @@ contract Nodes is AccessManagedUpgradeable, INodes {
 
             assert(_passiveNodeIdByAddress.remove(nodeOwner, id));
             if (_passiveNodeIdByAddress.lengthOf(nodeOwner) == 0) {
-                _passiveNodeAddresses.remove(nodeOwner);
+                assert(_passiveNodeAddresses.remove(nodeOwner));
             }
             delete ownerChangeRequests[id];
-            emit PassiveNodeDeleted(id, nodeOwner, node.ip, node.port);
+            emit PassiveNodeDeleted(id, nodeOwner, ip, port);
         }
-
-        delete nodes[id];
-
 
         statusContract.nodeRemoved(id);
         // may send tokens, should be the very last

--- a/contracts/Nodes.sol
+++ b/contracts/Nodes.sol
@@ -434,7 +434,6 @@ contract Nodes is AccessManagedUpgradeable, INodes {
             assert(_usedDomainNames.remove(newName));
         }
         address nodeOwner = node.nodeAddress;
-        delete nodes[id];
         IStatus statusContract = IStatus(committeeContract.status());
         bool isActive = _isActiveNode(id);
         IStaking stakingContract = IStaking(committeeContract.staking());
@@ -450,13 +449,19 @@ contract Nodes is AccessManagedUpgradeable, INodes {
         }
         else {
             assert(_passiveNodeIds.remove(id));
-            assert(_passiveNodeAddresses.remove(nodeOwner));
+
             assert(_passiveNodeIdByAddress.remove(nodeOwner, id));
+            if (_passiveNodeIdByAddress.lengthOf(nodeOwner) == 0) {
+                _passiveNodeAddresses.remove(nodeOwner);
+            }
             delete ownerChangeRequests[id];
             emit PassiveNodeDeleted(id, nodeOwner, node.ip, node.port);
         }
-        statusContract.nodeRemoved(id);
 
+        delete nodes[id];
+
+
+        statusContract.nodeRemoved(id);
         // may send tokens, should be the very last
         if (isActive) {
             stakingContract.nodeRemoved(id);

--- a/test/Nodes.ts
+++ b/test/Nodes.ts
@@ -92,7 +92,7 @@ describe("Nodes", function () {
         expect(await nodesContract.getActiveNodeIds()).to.include(nodeId);
         expect(await nodesContract.activeNodeExists(nodeId)).to.eql(true);
 
-        await nodesContract.connect(deployer).deleteNode(nodeId);
+        await expect(nodesContract.connect(deployer).deleteNode(nodeId)).to.emit(nodesContract, "ActiveNodeDeleted").withArgs(nodeId, deployer.address, MOCK_IP_0_BYTES, 8000);
 
         await expect(nodesContract.getNode(nodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
         expect(await nodesContract.getActiveNodeIds()).to.not.include(nodeId);
@@ -178,6 +178,38 @@ describe("Nodes", function () {
 
         const allPassiveNodeIds = await nodesContract.getPassiveNodeIds();
         expect(allPassiveNodeIds.length).to.eql(0);
+
+    });
+
+    it("should remove passive node addresses only if it does not own any other node", async () => {
+        await nodesContract.registerPassiveNode(MOCK_IPV6_BYTES, 8000);
+        const [passiveNodeId] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
+        const passiveNode = await nodesContract.getNode(passiveNodeId);
+        expect(passiveNode.id).to.equal(passiveNodeId);
+        expect(passiveNode.port).to.equal(8000n);
+        expect(Buffer.from(getBytes(passiveNode.ip))).to.eql(MOCK_IPV6_BYTES);
+        expect(passiveNode.nodeAddress).to.equal(deployer.address);
+        expect(await nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.include(passiveNodeId);
+
+        await nodesContract.registerPassiveNode(MOCK_IP_0_BYTES, 8000);
+
+        const [, passiveNodeId2] = await nodesContract.getPassiveNodeIdsForAddress(deployer.address);
+        expect(await nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.eql([passiveNodeId, passiveNodeId2]);
+
+        await expect(nodesContract.connect(deployer).deleteNode(passiveNodeId)).to.emit(nodesContract, "PassiveNodeDeleted").withArgs(passiveNodeId, deployer.address, MOCK_IPV6_BYTES, 8000);
+        await expect(nodesContract.getNode(passiveNodeId)).to.be.revertedWithCustomError(nodesContract, "NodeDoesNotExist");
+
+        await expect(nodesContract.registerNode(MOCK_IPV6_BYTES, deployerPubKey, 8000)).to.be.revertedWithCustomError(nodesContract, "AddressInUseByPassiveNodes");
+        expect(await nodesContract.getPassiveNodeIdsForAddress(deployer.address)).to.eql([passiveNodeId2]);
+
+        expect((await nodesContract.getPassiveNodeIds()).length).to.eql(1);
+
+        await expect(nodesContract.connect(deployer).deleteNode(passiveNodeId2)).to.emit(nodesContract, "PassiveNodeDeleted").withArgs(passiveNodeId2, deployer.address, MOCK_IP_0_BYTES, 8000);
+
+        expect((await nodesContract.getPassiveNodeIds()).length).to.eql(0);
+
+        // Address is free now
+        await expect(nodesContract.registerNode(MOCK_IPV6_BYTES, deployerPubKey, 8000)).to.be.fulfilled;
 
     });
 


### PR DESCRIPTION
Fixes #143 

Did not move `delete nodes[id]` to the end of the function to follow slither recommendations. As we now call rewardWallet.flush() on deletion, it recommends delete statement to appear first