### PR TITLE
fixes nodeCreated in Staking

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -214,12 +214,16 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
         if(_rewardWallets[node] == IRewardWallet(payable(0))) {
             _deployRewardWallet(node);
         }
+
+        // Node should be set as disabled with 0 stake before anything
+        // SelfStake will be added (If any) while node is disabled
+        assert(_disabledNodesBalances.set(node, FundLibrary.ZERO_FAIR));
+
         _updateNodeFeeRate(node, DEFAULT_FEE_RATE);
         _checkProvidedSelfStake(node);
         if (msg.value > 0) {
             _stakeFor(node, nodeAddress);
         }
-        assert(_disabledNodesBalances.set(node, FundLibrary.ZERO_FAIR));
     }
 
     function nodeRemoved(NodeId node) external override restricted {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1372,9 +1372,11 @@ describe("Staking", () => {
             );
 
             nodeId = await nodes.getNodeId(nodeWallet.address);
+        });
 
-            // Enable the node manually
-            await staking.enable(nodeId);
+        it("should allow a user to stake", async () => {
+            // should be able to stake
+            await staking.connect(regularUser).stake(nodeId, {value: ethers.parseEther("1")});
         });
 
         it("should prevent node owners from retrieving their stake while their node exists", async () => {


### PR DESCRIPTION
Fixes #188 

- Order of execution changed in nodeCreated.

- Added test that reproduces the old issue.

- removed manual enabling of node in tests where it's not a necessary precondition.