### PR TITLE
Disable with zero stake

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -351,7 +351,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
             return 0;
         }
         Fair totalBalance = _getTotalBalance();
-        assert((totalBalance == FundLibrary.ZERO_FAIR) == (_rootFund.totalCredits == FundLibrary.ZERO_CREDIT));
         uint256 unPulledCredits = 0;
         uint256 rewardWalletBalance = address(_rewardWallets[node]).balance;
         if (rewardWalletBalance > 0) {

--- a/contracts/utils/Fund.sol
+++ b/contracts/utils/Fund.sol
@@ -58,6 +58,7 @@ library FundLibrary {
 
     Fair private constant ALLOWED_ERROR = Fair.wrap(1e9);
 
+    error DepositAmountTooLow(Fair amount);
     error NotEnoughStaked(Fair staked);
     error NotEnoughFee(Fair earnedFee);
     error RoundingErrorTooHigh(Fair roundingError);
@@ -90,7 +91,8 @@ library FundLibrary {
         Fair holderBalance = getBalance(fund, fundBalance, holder);
         Credit credits;
         if (holderBalance == amount) {
-            credits = fund.credits.get(holder);
+            (, Credit c) = fund.credits.tryGet(holder);
+            credits = c;
         } else {
             credits = _toCreditsRoundedUp(fund, fundBalance, amount);
         }
@@ -135,6 +137,9 @@ library FundLibrary {
         fund.lastBalance = fundBalance + amount;
         Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
         _checkAllowedError(holderBalance, balanceAfter, amount + delayedReward);
+
+        // Blocks creation of phantom credits
+        require(balanceAfter > ZERO_FAIR, DepositAmountTooLow(amount));
     }
 
     function updateTotalBalance(Fund storage fund, Fair fundBalance) internal {
@@ -215,7 +220,6 @@ library FundLibrary {
         private
         returns (Fair removed)
     {
-        _processBalanceChange(fund, fundBalance);
         (bool exists, Credit holderCredits) = fund.credits.tryGet(holder);
         if (holderCredits < amount) {
             revert NotEnoughStaked(_toFairRoundedDown(fund, fundBalance, holderCredits));

--- a/contracts/utils/Fund.sol
+++ b/contracts/utils/Fund.sol
@@ -58,7 +58,6 @@ library FundLibrary {
 
     Fair private constant ALLOWED_ERROR = Fair.wrap(1e9);
 
-    error DepositAmountTooLow(Fair amount);
     error NotEnoughStaked(Fair staked);
     error NotEnoughFee(Fair earnedFee);
     error RoundingErrorTooHigh(Fair roundingError);
@@ -88,17 +87,19 @@ library FundLibrary {
         internal
     {
         _processBalanceChange(fund, fundBalance);
-        Fair holderBalance = getBalance(fund, fundBalance, holder);
-        Credit credits;
-        if (holderBalance == amount) {
-            (, Credit c) = fund.credits.tryGet(holder);
-            credits = c;
-        } else {
-            credits = _toCreditsRoundedUp(fund, fundBalance, amount);
+        if (amount > ZERO_FAIR) {
+            Fair holderBalance = getBalance(fund, fundBalance, holder);
+            Credit credits;
+
+            if (holderBalance == amount) {
+                credits = fund.credits.get(holder);
+            } else {
+                credits = _toCreditsRoundedUp(fund, fundBalance, amount);
+            }
+            _remove(fund, fundBalance, holder, credits);
+            Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
+            _checkAllowedError(holderBalance, balanceAfter, amount);
         }
-        _remove(fund, fundBalance, holder, credits);
-        Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
-        _checkAllowedError(holderBalance, balanceAfter, amount);
     }
 
     function setFeeRate(
@@ -138,8 +139,11 @@ library FundLibrary {
         Fair balanceAfter = getBalance(fund, fund.lastBalance, holder);
         _checkAllowedError(holderBalance, balanceAfter, amount + delayedReward);
 
-        // Blocks creation of phantom credits
-        require(balanceAfter > ZERO_FAIR, DepositAmountTooLow(amount));
+        // Credits that result in zero balance are removed
+        if (ZERO_CREDIT < credits && balanceAfter == ZERO_FAIR) {
+            assert(fund.credits.remove(holder));
+            fund.totalCredits = fund.totalCredits - credits;
+        }
     }
 
     function updateTotalBalance(Fund storage fund, Fair fundBalance) internal {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1250,7 +1250,7 @@ describe("Staking", () => {
         // Should it be true? It is with current implementation
         expect(await staking.isNodeEnabled(node.id)).to.be.eql(true);
         await grantNetworkRewards(staking, stakingReward);
-        await grantNodeRewards(staking, [node.id], walletReward);
+        await grantNodeRewards(staking, node.id, walletReward);
 
         await status.connect(node.wallet).alive();
     });
@@ -1316,7 +1316,7 @@ describe("Staking", () => {
         // All nodes sent alive. Node is not whitelisted so it should not be enabled
         expect(await staking.isNodeEnabled(node.id)).to.be.equal(false);
         await grantNetworkRewards(staking, stakingReward);
-        await grantNodeRewards(staking, [18n], walletReward);
+        await grantNodeRewards(staking, 18n, walletReward);
 
         expect(await staking.getNodeTotalStake(node.id)).to.be.eql(walletReward);
         expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(walletReward);

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1,5 +1,5 @@
 import chai, { assert, expect } from "chai";
-import { grantRewardToNode, registeredOnlyNodes, sendHeartbeat, stakedNodes, whitelistedNodes } from "./tools/fixtures";
+import { grantNodeRewards, grantNetworkRewards, registeredOnlyNodes, sendHeartbeat, stakedNodes, whitelistedNodes } from "./tools/fixtures";
 import { ethers } from "hardhat";
 import { zip } from "lodash";
 import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
@@ -1249,8 +1249,8 @@ describe("Staking", () => {
         await staking.connect(user1).requestRetrieveAll(node.id);
         // Should it be true? It is with current implementation
         expect(await staking.isNodeEnabled(node.id)).to.be.eql(true);
-
-        await grantRewardToNode(staking, node.id, stakingReward, walletReward);
+        await grantNetworkRewards(staking, stakingReward);
+        await grantNodeRewards(staking, [node.id], walletReward);
 
         await status.connect(node.wallet).alive();
     });
@@ -1270,9 +1270,8 @@ describe("Staking", () => {
         const [node,] = nodesData;
         const stakingReward = ethers.parseEther("1");
         const walletReward = 10n**14n;
-
-        await grantRewardToNode(staking, 21n, stakingReward, walletReward);
-        await grantRewardToNode(staking, node.id, stakingReward, walletReward);
+        await grantNetworkRewards(staking, stakingReward * 2n);
+        await grantNodeRewards(staking, [node.id, 21n], walletReward);
 
         await status.whitelistNode(21n);
 
@@ -1294,7 +1293,8 @@ describe("Staking", () => {
         expect(await staking.getNodeShare(node.id)).to.be.eql(0n);
         // All nodes sent alive. Node is not whitelisted so it should not be enabled
         expect(await staking.isNodeEnabled(node.id)).to.be.equal(false);
-        await grantRewardToNode(staking, 18n, stakingReward, walletReward);
+        await grantNetworkRewards(staking, stakingReward);
+        await grantNodeRewards(staking, [18n], walletReward);
 
         expect(await staking.getNodeTotalStake(node.id)).to.be.eql(walletReward);
         expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(walletReward);

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1,12 +1,12 @@
 import chai, { assert, expect } from "chai";
-import { registeredOnlyNodes, sendHeartbeat, stakedNodes, whitelistedNodes } from "./tools/fixtures";
+import { grantRewardToNode, registeredOnlyNodes, sendHeartbeat, stakedNodes, whitelistedNodes } from "./tools/fixtures";
 import { ethers } from "hardhat";
 import { zip } from "lodash";
 import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import { skipTime } from "./tools/time";
 import { Nodes, Staking } from "../typechain-types";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
-import { BigNumberish, HDNodeWallet } from "ethers";
+import { HDNodeWallet } from "ethers";
 
 chai.should();
 
@@ -1083,10 +1083,6 @@ describe("Staking", () => {
         // User is protected from depositing and losing ALL funds
         await expect(staking.connect(user).stake(node, {value: sufficientlyHighAmount}))
         .to.be.revertedWithCustomError(staking, "RoundingErrorTooHigh").withArgs(sufficientlyHighAmount);
-
-        // Blocks creation of phantom credits - 1 wei lower than allowed error
-        await expect(staking.connect(user).stake(node, {value: 1n}))
-        .to.be.revertedWithCustomError(staking, "DepositAmountTooLow").withArgs(1n);
     });
 
     it("All calculations should not overflow with MAX_STAKED_FAIR", async () => {
@@ -1238,6 +1234,27 @@ describe("Staking", () => {
         await setBalance(await ethers.resolveAddress(staking), ethers.parseEther("2"));
         await status.connect(node.wallet).alive();
     });
+    it("should not cause alive() to PANIC", async() => {
+        const {nodesData, staking, status} = await registeredOnlyNodes();
+        const [node,] = nodesData;
+        const stakingReward = ethers.parseEther("1");
+        const [user1,] = await ethers.getSigners();
+        const walletReward = 10n**14n;
+
+        await staking.connect(node.wallet).setFeeRate(0);
+        await staking.connect(user1).stake(node.id, {value: ethers.parseEther("1")});
+        await status.connect(node.wallet).alive();
+        await status.whitelistNode(node.id);
+        expect(await staking.isNodeEnabled(node.id)).to.be.eql(true);
+        await staking.connect(user1).requestRetrieveAll(node.id);
+        // Should it be true? It is with current implementation
+        expect(await staking.isNodeEnabled(node.id)).to.be.eql(true);
+
+        await grantRewardToNode(staking, node.id, stakingReward, walletReward);
+
+        await status.connect(node.wallet).alive();
+    });
+
 
     it("Should disable/blacklist node with 0 stake", async () => {
         const {nodesData, staking, status} = await registeredOnlyNodes();
@@ -1253,14 +1270,10 @@ describe("Staking", () => {
         const [node,] = nodesData;
         const stakingReward = ethers.parseEther("1");
         const walletReward = 10n**14n;
-        const grantRewards = async (node: BigNumberish) => {
-            const balance = await ethers.provider.getBalance(staking);
-            await setBalance(await ethers.resolveAddress(staking),balance + stakingReward);
-            const rewardWallet = await staking.getRewardWallet(node);
-            await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
-        }
-        await grantRewards(21n);
-        await grantRewards(node.id);
+
+        await grantRewardToNode(staking, 21n, stakingReward, walletReward);
+        await grantRewardToNode(staking, node.id, stakingReward, walletReward);
+
         await status.whitelistNode(21n);
 
         await staking.connect(node.wallet).setFeeRate(24);
@@ -1281,7 +1294,8 @@ describe("Staking", () => {
         expect(await staking.getNodeShare(node.id)).to.be.eql(0n);
         // All nodes sent alive. Node is not whitelisted so it should not be enabled
         expect(await staking.isNodeEnabled(node.id)).to.be.equal(false);
-        await grantRewards(18n);
+        await grantRewardToNode(staking, 18n, stakingReward, walletReward);
+
         expect(await staking.getNodeTotalStake(node.id)).to.be.eql(walletReward);
         expect(await staking.getEarnedFeeAmount(node.id)).to.be.eql(walletReward);
         await status.whitelistNode(node.id);

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1083,6 +1083,10 @@ describe("Staking", () => {
         // User is protected from depositing and losing ALL funds
         await expect(staking.connect(user).stake(node, {value: sufficientlyHighAmount}))
         .to.be.revertedWithCustomError(staking, "RoundingErrorTooHigh").withArgs(sufficientlyHighAmount);
+
+        // Blocks creation of phantom credits - 1 wei lower than allowed error
+        await expect(staking.connect(user).stake(node, {value: 1n}))
+        .to.be.revertedWithCustomError(staking, "DepositAmountTooLow").withArgs(1n);
     });
 
     it("All calculations should not overflow with MAX_STAKED_FAIR", async () => {
@@ -1233,6 +1237,15 @@ describe("Staking", () => {
         await setBalance(rewardWallet, ethers.parseEther("3"));
         await setBalance(await ethers.resolveAddress(staking), ethers.parseEther("2"));
         await status.connect(node.wallet).alive();
+    });
+
+    it("Should disable/blacklist node with 0 stake", async () => {
+        const {nodesData, staking, status} = await registeredOnlyNodes();
+        await status.whitelistNode(12);
+        await staking.stake(12, {value: 200});
+        await status.connect(nodesData[11].wallet).alive();
+        await staking.requestRetrieveAll(12);
+        await status.removeNodeFromWhitelist(12);
     });
 
     it("Should update earned fees accordingly", async () => {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -1265,6 +1265,28 @@ describe("Staking", () => {
         await status.removeNodeFromWhitelist(12);
     });
 
+    it("Should not add user as a holder if staking very small amount", async () => {
+        const {nodesData, staking, status} = await registeredOnlyNodes();
+        await status.whitelistNode(1);
+        await staking.stake(1, {value: 1});
+        await status.connect(nodesData[0].wallet).alive();
+        const [deployer, user1, user2] = await ethers.getSigners();
+        await staking.connect(user1).stake(1, {value: 2});
+        await staking.connect(nodesData[0].wallet).setFeeRate(0);
+        await setBalance(await staking.getRewardWallet(1), HUGE_AMOUNT_OF_FAIR);
+
+        expect(await staking.getNodeTotalStake(1)).to.be.eql(HUGE_AMOUNT_OF_FAIR + 1n + 2n);
+        expect(await staking.getStakedToNodeAmountFor(1, deployer)).to.be.eql(HUGE_AMOUNT_OF_FAIR / 3n + 1n);
+        expect(await staking.getStakedToNodeAmountFor(1, user1)).to.be.eql(HUGE_AMOUNT_OF_FAIR * 2n / 3n + 2n);
+        expect(await staking.getDelegatorsToNodeCount(1)).to.be.eql(2n);
+        await staking.connect(user2).stake(1, {value: 1});
+
+        // tx accepted, user has no stake, but amount was received by the node
+        expect(await staking.getStakedToNodeAmountFor(1, user2)).to.be.eql(0n);
+        expect(await staking.getNodeTotalStake(1)).to.be.eql(HUGE_AMOUNT_OF_FAIR + 1n + 2n + 1n);
+        expect(await staking.getDelegatorsToNodeCount(1)).to.be.eql(2n);
+    });
+
     it("Should update earned fees accordingly", async () => {
         const {nodesData, staking, status} = await registeredOnlyNodes();
         const [node,] = nodesData;

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -80,31 +80,22 @@ export const sendHeartbeat = async (status: Status, nodesData: NodeData[]) => {
 }
 
 
-export const grantRewardToNode = async (
+export const grantNetworkRewards = async (
     staking: Staking,
-    node: BigNumberish,
     stakingReward: bigint,
-    walletReward: bigint
 ) => {
     const balance = await ethers.provider.getBalance(staking);
     await setBalance(await ethers.resolveAddress(staking), balance + stakingReward);
-    const rewardWallet = await staking.getRewardWallet(node);
-    await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
 }
 
-export const grantRewardsToEligibleNodes = async (
+export const grantNodeRewards = async (
     staking: Staking,
     nodes: BigNumberish[],
-    stakingReward: bigint,
     walletReward: bigint
 ) => {
-    const balance = await ethers.provider.getBalance(staking);
-    await setBalance(await ethers.resolveAddress(staking), balance + stakingReward);
     for (const node of nodes) {
-        if(await staking.isNodeEnabled(node)) {
-            const rewardWallet = await staking.getRewardWallet(node);
-            await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
-        }
+        const rewardWallet = await staking.getRewardWallet(node);
+        await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
     }
 }
 

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -90,9 +90,12 @@ export const grantNetworkRewards = async (
 
 export const grantNodeRewards = async (
     staking: Staking,
-    nodes: BigNumberish[],
+    nodes: BigNumberish | BigNumberish[],
     walletReward: bigint
 ) => {
+    if (!Array.isArray(nodes)){
+        nodes = [nodes];
+    }
     for (const node of nodes) {
         const rewardWallet = await staking.getRewardWallet(node);
         await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -1,10 +1,11 @@
 // cspell:words hexlify
 
 import {
-    loadFixture
+    loadFixture,
+    setBalance
 } from "@nomicfoundation/hardhat-network-helpers";
 import { deploy, NodeStruct } from "../../migrations/deploy";
-import { HDNodeWallet, Wallet } from "ethers";
+import { BigNumberish, HDNodeWallet, Wallet } from "ethers";
 import { ethers } from "hardhat";
 import { IDkg, Nodes, Status, Staking } from "../../typechain-types";
 import { getPublicKey } from "./signatures";
@@ -75,6 +76,35 @@ const whitelistNodes = async (status: Status, nodesData: NodeData[]) => {
 export const sendHeartbeat = async (status: Status, nodesData: NodeData[]) => {
     for (const node of nodesData) {
         await status.connect(node.wallet).alive();
+    }
+}
+
+
+export const grantRewardToNode = async (
+    staking: Staking,
+    node: BigNumberish,
+    stakingReward: bigint,
+    walletReward: bigint
+) => {
+    const balance = await ethers.provider.getBalance(staking);
+    await setBalance(await ethers.resolveAddress(staking), balance + stakingReward);
+    const rewardWallet = await staking.getRewardWallet(node);
+    await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
+}
+
+export const grantRewardsToEligibleNodes = async (
+    staking: Staking,
+    nodes: BigNumberish[],
+    stakingReward: bigint,
+    walletReward: bigint
+) => {
+    const balance = await ethers.provider.getBalance(staking);
+    await setBalance(await ethers.resolveAddress(staking), balance + stakingReward);
+    for (const node of nodes) {
+        if(await staking.isNodeEnabled(node)) {
+            const rewardWallet = await staking.getRewardWallet(node);
+            await setBalance(rewardWallet, await ethers.provider.getBalance(rewardWallet) + walletReward);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #197 

- Fund.remove() should 'work' even if holder is not in the map.
- I propose Fund.supply() to block ammounts that result in 0 balance, as it creates 'phantom' credits
- As a result of the previous, I propose that committee should only mark a node as enabled over a threshold higher than 0 (I set it to selfStakeRequirement, but another value can be thought of) - Personaly I would recomend a value (can be constant) equal or higher than ALLOWED_ERROR.