### PR TITLE
remove pullRewards from disable

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -168,7 +168,6 @@ contract Staking is AccessManagedUpgradeable, ReentrancyGuardUpgradeable, IStaki
     }
 
     function disable(NodeId node) external override restricted {
-        _pullReward(node);
         Fair balance = _getTotalBalance();
         Fair nodeFundBalance = _rootFund.getBalance(balance, FundLibrary.nodeToHolder(node));
         _rootFund.remove(


### PR DESCRIPTION
Related to #201 - Improvement for alive() 

Saves ~70k gas for alive() calls that disable a node and removes duplicating the NodeLosesEligibility() event on _setIlegible()

https://testnet-explorer.fair.cloud/tx/0xb0a04bb6770b21b548a983f0e8a1319f68b9484ed7c3cb458f8d82339e78fae8?tab=logs -> duplicated NodeLosesEligibility()
