### PR TITLE
Add compile step to dokcer image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ ENV NODE_OPTIONS="--max-old-space-size=2048"
 COPY . .
 # previous command has overwritten the .yarnrc.yml file
 RUN sed -i 's/nodeLinker: pnpm/nodeLinker: node-modules/' .yarnrc.yml
-RUN npx hardhat compile
+RUN yarn hardhat compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ ENV NODE_OPTIONS="--max-old-space-size=2048"
 COPY . .
 # previous command has overwritten the .yarnrc.yml file
 RUN sed -i 's/nodeLinker: pnpm/nodeLinker: node-modules/' .yarnrc.yml
+RUN npx hardhat compile


### PR DESCRIPTION
This pull request introduces a build step to compile the Hardhat project during the Docker image build process.

Build process update:

* Added `RUN npx hardhat compile` to the `Dockerfile` to ensure the project is compiled as part of the Docker image creation.