### PR TITLE
Add authentication to build_and_publish_types script

### DIFF
--- a/scripts/build_and_publish_types.sh
+++ b/scripts/build_and_publish_types.sh
@@ -23,6 +23,19 @@ yarn buildTypesPackage
 
 cd "$TYPES_PACKAGE_DIR"
 
+echo "Configuring npm authentication..."
+cat > .npmrc << EOF
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+EOF
+
+echo "Verifying authentication..."
+if ! npm whoami; then
+  echo "Error: npm authentication failed"
+  rm -f .npmrc
+  exit 1
+fi
+
 echo "Publishing types package..."
 TAG=""
 if [[ "$BRANCH" != "stable" ]]; then
@@ -30,3 +43,6 @@ if [[ "$BRANCH" != "stable" ]]; then
 fi
 
 npm publish --access public $TAG
+
+# Clean up .npmrc for security
+rm -f .npmrc

--- a/scripts/build_and_publish_types.sh
+++ b/scripts/build_and_publish_types.sh
@@ -10,6 +10,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 TYPES_PACKAGE_DIR="$PROJECT_ROOT/types-package"
 
+# Cleanup function to ensure .npmrc is always removed
+cleanup() {
+  rm -f "$TYPES_PACKAGE_DIR/.npmrc"
+}
+
+# Trap to ensure cleanup runs even if script fails or is interrupted
+trap cleanup EXIT
+
 cd "$PROJECT_ROOT"
 
 echo "Ensuring dependencies installed..."
@@ -29,6 +37,9 @@ cat > .npmrc << EOF
 registry=https://registry.npmjs.org/
 EOF
 
+# Set restrictive permissions on .npmrc to protect the auth token
+chmod 600 .npmrc
+
 echo "Verifying authentication..."
 if ! npm whoami; then
   echo "Error: npm authentication failed"
@@ -44,5 +55,4 @@ fi
 
 npm publish --access public $TAG
 
-# Clean up .npmrc for security
-rm -f .npmrc
+

--- a/scripts/build_and_publish_types.sh
+++ b/scripts/build_and_publish_types.sh
@@ -6,12 +6,16 @@ set -e
 : "${VERSION?Need to set VERSION}"
 : "${NODE_AUTH_TOKEN?Need to set NODE_AUTH_TOKEN}"
 
+# Optional: Set DRY_RUN=1 to skip actual publishing
+DRY_RUN="${DRY_RUN:-0}"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 TYPES_PACKAGE_DIR="$PROJECT_ROOT/types-package"
 
 # Cleanup function to ensure .npmrc is always removed
 cleanup() {
+  echo "Cleaning up .npmrc file..."
   rm -f "$TYPES_PACKAGE_DIR/.npmrc"
 }
 
@@ -43,7 +47,6 @@ chmod 600 .npmrc
 echo "Verifying authentication..."
 if ! npm whoami; then
   echo "Error: npm authentication failed"
-  rm -f .npmrc
   exit 1
 fi
 
@@ -53,6 +56,12 @@ if [[ "$BRANCH" != "stable" ]]; then
   TAG="--tag $BRANCH"
 fi
 
-npm publish --access public $TAG
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY RUN: Would execute: npm publish --access public $TAG"
+  echo "Package contents:"
+  npm pack --dry-run
+else
+  npm publish --access public $TAG
+fi
 
 

--- a/scripts/build_and_publish_types.sh
+++ b/scripts/build_and_publish_types.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# cspell:ignore npmjs
 set -e
 
 : "${BRANCH?Need to set BRANCH}"


### PR DESCRIPTION
Fixes #241

The build and publish types script was not handling NPM authentication so publish fails. To make the script self-contained and not work only in CI, we add creation of .npmrc file in the script itself so that only a valid AUTH_TOKEN is required.